### PR TITLE
Add prebuild script to create template external_api_keys.dart file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ sudo apt install build-essential debhelper cmake libclang-dev libncurses5-dev cl
 sudo apt install unzip automake build-essential file pkg-config git python libtool libtinfo5 cmake openjdk-8-jre-headless
 ```
 
+Run prebuild script
+
+```
+cd scripts
+./prebuild.sh
+// when finished go back to the root directory
+cd ..
+```
+
 Building plugins for Android
 ```
 cd scripts/android/

--- a/scripts/prebuild.sh
+++ b/scripts/prebuild.sh
@@ -1,0 +1,6 @@
+# Create template lib/external_api_keys.dart file if it doesn't already exist
+KEYS=../lib/external_api_keys.dart
+if ! test -f "$KEYS"; then
+    echo 'prebuild.sh: creating template lib/external_api_keys.dart file'
+    echo 'const kChangeNowApiKey = "";' > $KEYS
+fi


### PR DESCRIPTION
Adds a script that creates a template external_api_keys.dart file if it doesn't exist for new contributors that don't have the sidechannel-distributed production API keys and documents its use in README.md