### PR TITLE
Add setup script and expand upon dev env setup instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following prerequisities can be installed with the setup script `scripts/set
 - Android setup ([Android Studio](https://developer.android.com/studio) and subsequent dependencies)
 
 ### Scripted setup
-`scripts/setup.sh` is provided as a tool to set up a stock Ubuntu 20.04 installation for building.  This script should skip the entire [Manual setup](#manual-setup) section below and prepare you for [running](#running)
+[`scripts/setup.sh`](https://github.com/cypherstack/stack_wallet/blob/main/scripts/setup.sh) is provided as a tool to set up a stock Ubuntu 20.04 installation for building: download the script and run it anywhere.  This script should skip the entire [Manual setup](#manual-setup) section below and prepare you for [running](#running).  It will set up the stack_wallet repository in `~/projects/stack_wallet` and build it there. 
 
 ### Manual setup
 After installing the prerequisites listed above, download the code and init the submodules

--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ sudo snap install android-studio --classic
 
 Use Tools > SDK Manager to install the SDK Tools > Android SDK (API 30), SDK Tools > NDK, SDK Tools > Android SDK command line tools, and SDK Tools > CMake
 
-Then install the Flutter plugin and restart the IDE.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style
+Then install the Flutter plugin and restart the IDE.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style.  If you have problems with the Dart SDK, make sure to run `flutter` in a terminal to download it (use `source ~/.bashrc` to update your environment variables if you're still using the same terminal from which you ran `setup.sh`)
 
 Make a Pixel 4 (API 30) x86_64 emulator with 2GB of storage space for emulation

--- a/README.md
+++ b/README.md
@@ -17,15 +17,22 @@ Highlights include:
 - Custom Nodes.
 - Open source software.
 
-## Build and run
+## Building
 ### Prerequisites
 - The only OS supported for building is Ubuntu 20.04
 - A machine with at least 100 GB of Storage
+
+The following prerequisities can be installed with the setup script `scripts/setup.sh` or manually as described below:
+
 - Flutter 3.0.5 [(install manually or with git, do not install with snap)](https://docs.flutter.dev/get-started/install)
 - Dart SDK Requirement (>=2.17.0, up until <3.0.0)
 - Android setup ([Android Studio](https://developer.android.com/studio) and subsequent dependencies)
 
-After that download the project and init the submodules
+### Scripted setup
+`scripts/setup.sh` is provided as a tool to set up a stock Ubuntu 20.04 installation for building.  This script should skip the entire [Manual setup](#manual-setup) section below and prepare you for [running](#running)
+
+### Manual setup
+After installing the prerequisites listed above, download the code and init the submodules
 ```
 git clone https://github.com/cypherstack/stack_wallet.git
 cd stack_wallet
@@ -57,7 +64,6 @@ cd scripts
 cd ..
 ```
 
-
 Remove pre-installed system libraries for the following packages built by cryptography plugins in the crypto_plugins folder: `boost iconv libjson-dev libsecret openssl sodium unbound zmq`.  You can use
 ```
 sudo apt list --installed | grep boost
@@ -76,7 +82,7 @@ cd scripts/android/
 cd ../..
 ```
 
-Building plugins for testing on Linux
+Building plugins for Linux
 
 ```
 cd scripts/linux/
@@ -85,10 +91,33 @@ cd scripts/linux/
 cd ../..
 ```
 
-Finally, plug in your android device or use the emulator available via Android Studio and then run the following commands:
+## Running
+### Android
+Plug in your android device or use the emulator available via Android Studio and then run the following commands:
 ```
 flutter pub get
-flutter run
+flutter run android
 ```
 
 Note on Emulators: Only x86_64 emulators are supported, x86 emulators will not work
+
+### Linux
+Plug in your android device or use the emulator available via Android Studio and then run the following commands:
+```
+flutter pub get Linux
+flutter run linux
+```
+
+## Android Studio
+Android Studio is the recommended IDE for development, not just for launching on Android devices and emulators but also for Linux desktop development.  Install it and configure it as follows:
+```
+# setup android studio
+sudo apt install -y openjdk-11-jdk
+sudo snap install android-studio --classic
+```
+
+Use Tools > SDK Manager to install the Android SDK, NDK, Android SDK command line tools, and cmake
+
+Then install the Flutter plugin.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style
+
+Make a Pixel 4 (API 30) x86_64 emulator with 2GB of storage space for emulation

--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ sudo snap install android-studio --classic
 
 Use Tools > SDK Manager to install the SDK Tools > Android SDK (API 30), SDK Tools > NDK, SDK Tools > Android SDK command line tools, and SDK Tools > CMake
 
-Then install the Flutter plugin.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style
+Then install the Flutter plugin and restart the IDE.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style
 
 Make a Pixel 4 (API 30) x86_64 emulator with 2GB of storage space for emulation

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sudo apt install -y openjdk-11-jdk
 sudo snap install android-studio --classic
 ```
 
-Use Tools > SDK Manager to install the Android SDK, NDK, Android SDK command line tools, and cmake
+Use Tools > SDK Manager to install the SDK Tools > Android SDK (API 30), SDK Tools > NDK, SDK Tools > Android SDK command line tools, and SDK Tools > CMake
 
 Then install the Flutter plugin.  In Android Studio's options for the Flutter language, enable auto format on save to match the project's code style
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+sudo apt update && sudo apt upgrade -y && sudo apt dist-upgrade -y
+mkdir "$HOME/development"
+mkdir "$HOME/projects"
+sudo apt install -y git build-essential curl
+export DEVELOPMENT=$HOME/development
+export PROJECTS=$HOME/projects
+
+# setup flutter
+sudo apt install -y unzip pkg-config clang cmake ninja-build libgtk-3-dev
+cd $DEVELOPMENT
+git clone https://github.com/flutter/flutter.git
+cd flutter 
+git checkout 3.0.3
+export FLUTTER_DIR=$(pwd)/bin
+echo 'export PATH="$PATH:'${FLUTTER_DIR}'"' >> ~/.bashrc
+source ~/.bashrc
+flutter doctor
+
+# setup stack_wallet github
+cd $PROJECTS
+git clone https://github.com/cypherstack/stack_wallet.git
+cd stack_wallet
+export STACK_WALLET=$(pwd)
+git submodule update --init --recursive
+
+# create template lib/external_api_keys.dart file if it doesn't already exist
+cd $STACK_WALLET
+cd scripts
+./prebuild.sh
+
+#install stack wallet dependencies
+sudo apt-get install -y unzip automake build-essential file pkg-config git python libtool libtinfo5 cmake openjdk-8-jre-headless libgit2-dev clang libncurses5-dev libncursesw5-dev zlib1g-dev llvm 
+
+sudo apt-get install -y debhelper libclang-dev cargo rustc opencl-headers libssl-dev ocl-icd-opencl-dev
+
+sudo apt-get install -y unzip automake build-essential file pkg-config git python libtool libtinfo5 cmake openjdk-8-jre-headless
+
+sudo apt install -y libc6-dev-i386
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh  -s -- -y
+cargo install cargo-ndk
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+# build stack wallet plugins
+cd $STACK_WALLET
+cd scripts/android
+./build_all.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,10 +25,12 @@ cd stack_wallet
 export STACK_WALLET=$(pwd)
 git submodule update --init --recursive
 
-# create template lib/external_api_keys.dart file if it doesn't already exist
-cd $STACK_WALLET
-cd scripts
-./prebuild.sh
+# Create template lib/external_api_keys.dart file if it doesn't already exist
+KEYS="$HOME/projects/stack_wallet/lib/external_api_keys.dart"
+if ! test -f "$KEYS"; then
+    echo 'prebuild.sh: creating template lib/external_api_keys.dart file'
+    echo 'const kChangeNowApiKey = "";' > $KEYS
+fi
 
 #install stack wallet dependencies
 sudo apt-get install -y unzip automake build-essential file pkg-config git python libtool libtinfo5 cmake openjdk-8-jre-headless libgit2-dev clang libncurses5-dev libncursesw5-dev zlib1g-dev llvm 


### PR DESCRIPTION
@msalazarm gave me this great `setup.sh` which we troubleshot today and is now working for taking to a fresh Ubuntu 20.04 installation to ready to build.  We should just test this again from a blank-slate 20.04 to confirm