### PR TITLE
Update setup.sh and prebuild.sh to add SimpleSwap API key const

### DIFF
--- a/scripts/prebuild.sh
+++ b/scripts/prebuild.sh
@@ -2,5 +2,5 @@
 KEYS=../lib/external_api_keys.dart
 if ! test -f "$KEYS"; then
     echo 'prebuild.sh: creating template lib/external_api_keys.dart file'
-    echo 'const kChangeNowApiKey = "";' > $KEYS
+    printf 'const kChangeNowApiKey = "";\nconst kSimpleSwapApiKey = "";' > $KEYS
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,7 +29,7 @@ git submodule update --init --recursive
 KEYS="$HOME/projects/stack_wallet/lib/external_api_keys.dart"
 if ! test -f "$KEYS"; then
     echo 'prebuild.sh: creating template lib/external_api_keys.dart file'
-    echo 'const kChangeNowApiKey = "";' > $KEYS
+    printf 'const kChangeNowApiKey = "";\nconst kSimpleSwapApiKey = "";' > $KEYS
 fi
 
 #install stack wallet dependencies


### PR DESCRIPTION
Missing `kSimpleSwapApiKey` in `lib/external_api_keys.dart` throws errors on build, so this addition to setup.sh and prebuild.sh adds an empty default const