### PR TITLE
Use native address validation for cryptonote coins

### DIFF
--- a/lib/services/coins/monero/monero_wallet.dart
+++ b/lib/services/coins/monero/monero_wallet.dart
@@ -1353,10 +1353,8 @@ class MoneroWallet extends CoinServiceAPI {
   Future<List<UtxoObject>> get unspentOutputs => throw UnimplementedError();
 
   @override
-  // TODO: implement validateAddress
   bool validateAddress(String address) {
-    bool valid = RegExp("[a-zA-Z0-9]{95}").hasMatch(address) ||
-        RegExp("[a-zA-Z0-9]{106}").hasMatch(address);
+    bool valid = walletBase!.validateAddress(address);
     return valid;
   }
 

--- a/lib/services/coins/wownero/wownero_wallet.dart
+++ b/lib/services/coins/wownero/wownero_wallet.dart
@@ -1378,10 +1378,8 @@ class WowneroWallet extends CoinServiceAPI {
   Future<List<UtxoObject>> get unspentOutputs => throw UnimplementedError();
 
   @override
-  // TODO: implement validateAddress
   bool validateAddress(String address) {
-    bool valid = RegExp("[a-zA-Z0-9]{95}").hasMatch(address) ||
-        RegExp("[a-zA-Z0-9]{106}").hasMatch(address);
+    bool valid = walletBase!.validateAddress(address);
     return valid;
   }
 

--- a/test/services/coins/monero/monero_wallet_test.dart
+++ b/test/services/coins/monero/monero_wallet_test.dart
@@ -60,19 +60,11 @@ void main() async {
       dirPath: '');
   late WalletCredentials credentials;
 
-  WidgetsFlutterBinding.ensureInitialized();
-  Directory appDir = (await getApplicationDocumentsDirectory());
-  if (Platform.isIOS) {
-    appDir = (await getLibraryDirectory());
-  }
-
   monero.onStartup();
 
   bool hiveAdaptersRegistered = false;
 
-  bool hiveAdaptersRegistered = false;
-
-  group("Mnemonic recovery", () {
+  group("Mainnet tests", () {
     setUp(() async {
       await setUpTestHive();
       if (!hiveAdaptersRegistered) {
@@ -87,7 +79,8 @@ void main() async {
         await wallets.put('currentWalletName', name);
 
         _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
-        walletService = monero.createMoneroWalletService(_walletInfoSource);
+        walletService = monero
+            .createMoneroWalletService(_walletInfoSource as Box<WalletInfo>);
       }
 
       try {
@@ -97,12 +90,12 @@ void main() async {
         final dirPath = await pathForWalletDir(name: name, type: type);
         path = await pathForWallet(name: name, type: type);
         credentials =
-            // //     creating a new wallet
-            // monero.createMoneroNewWalletCredentials(
-            //     name: name, language: "English");
-            // restoring a previous wallet
-            monero.createMoneroRestoreWalletFromSeedCredentials(
-                name: name, height: 2580000, mnemonic: testMnemonic);
+        // //     creating a new wallet
+        // monero.createMoneroNewWalletCredentials(
+        //     name: name, language: "English");
+        // restoring a previous wallet
+        monero.createMoneroRestoreWalletFromSeedCredentials(
+            name: name, height: 2580000, mnemonic: testMnemonic);
 
         walletInfo = WalletInfo.external(
             id: WalletBase.idFor(name, type),
@@ -129,30 +122,10 @@ void main() async {
       }
     });
 
-    test("Test address validation", () async { // TODO I'd like to refactor/separate this out so I can test addresses alone, without having to first create a wallet.
-      final wallet = await _walletCreationService.restoreFromSeed(credentials);
-      walletBase = wallet as MoneroWalletBase;
-
-      expect(
-          await walletBase!.validateAddress(''), false);
-      expect(
-          await walletBase!.validateAddress('4AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), true);
-      expect(
-          await walletBase!.validateAddress('4asdfkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gpjkl'), false);
-      expect(
-          await walletBase!.validateAddress('8AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), false);
-      expect(
-          await walletBase!.validateAddress('84kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), true);
-      expect(
-          await walletBase!.validateAddress('8asdfuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenjkl'), false);
-      expect(
-          await walletBase!.validateAddress('44kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), false);
-    });
-
     test("Test mainnet address generation from seed", () async {
       final wallet = await
-          // _walletCreationService.create(credentials);
-          _walletCreationService.restoreFromSeed(credentials);
+      // _walletCreationService.create(credentials);
+      _walletCreationService.restoreFromSeed(credentials);
       walletInfo.address = wallet.walletAddresses.address;
       //print(walletInfo.address);
 
@@ -160,6 +133,9 @@ void main() async {
       walletBase?.close();
       walletBase = wallet as MoneroWalletBase;
       //print("${walletBase?.seed}");
+
+      expect(
+          await walletBase!.validateAddress(walletInfo.address ?? ''), true);
 
       // print(walletBase);
       // loggerPrint(walletBase.toString());
@@ -180,6 +156,21 @@ void main() async {
           await walletBase!.getTransactionAddress(1, 1), mainnetTestData[1][1]);
       expect(
           await walletBase!.getTransactionAddress(1, 2), mainnetTestData[1][2]);
+
+      expect(
+          await walletBase!.validateAddress(''), false);
+      expect(
+          await walletBase!.validateAddress('4AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), true);
+      expect(
+          await walletBase!.validateAddress('4asdfkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gpjkl'), false);
+      expect(
+          await walletBase!.validateAddress('8AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), false);
+      expect(
+          await walletBase!.validateAddress('84kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), true);
+      expect(
+          await walletBase!.validateAddress('8asdfuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenjkl'), false);
+      expect(
+          await walletBase!.validateAddress('44kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), false);
     });
   });
   /*
@@ -238,6 +229,6 @@ Future<String> pathForWalletDir(
 }
 
 Future<String> pathForWallet(
-        {required String name, required WalletType type}) async =>
+    {required String name, required WalletType type}) async =>
     await pathForWalletDir(name: name, type: type)
         .then((path) => path + '/$name');

--- a/test/services/coins/monero/monero_wallet_test.dart
+++ b/test/services/coins/monero/monero_wallet_test.dart
@@ -92,7 +92,7 @@ void main() async {
   _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
   walletService = monero.createMoneroWalletService(_walletInfoSource);
 
-  group("Mainnet tests", () {
+  group("Mnemonic recovery", () {
     setUp(() async {
       try {
         // if (name?.isEmpty ?? true) {
@@ -131,6 +131,26 @@ void main() async {
         print(e);
         print(s);
       }
+    });
+
+    test("Test address validation", () async { // TODO I'd like to refactor/separate this out so I can test addresses alone, without having to first create a wallet.
+      final wallet = await _walletCreationService.restoreFromSeed(credentials);
+      walletBase = wallet as MoneroWalletBase;
+
+      expect(
+          await walletBase!.validateAddress(''), false);
+      expect(
+          await walletBase!.validateAddress('4AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), true);
+      expect(
+          await walletBase!.validateAddress('4asdfkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gpjkl'), false);
+      expect(
+          await walletBase!.validateAddress('8AeRgkWZsMJhAWKMeCZ3h4ZSPnAcW5VBtRFyLd6gBEf6GgJU2FHXDA6i1DnQTd6h8R3VU5AkbGcWSNhtSwNNPgaD48gp4nn'), false);
+      expect(
+          await walletBase!.validateAddress('84kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), true);
+      expect(
+          await walletBase!.validateAddress('8asdfuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenjkl'), false);
+      expect(
+          await walletBase!.validateAddress('44kYPuZ1eaVKGQhf26QPNWbSLQG16BywXdLYYShVrPNMLAUAWce5vcpRc78FxwRphrG6Cda7faCKdUMr8fUCH3peHPenvHy'), false);
     });
 
     test("Test mainnet address generation from seed", () async {

--- a/test/services/coins/monero/monero_wallet_test.dart
+++ b/test/services/coins/monero/monero_wallet_test.dart
@@ -1,43 +1,27 @@
-import 'dart:async';
 import 'dart:core';
 import 'dart:core' as core;
 import 'dart:io';
 import 'dart:math';
 
-import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
-import 'package:hive_test/hive_test.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
-
-import 'package:cw_core/monero_amount_format.dart';
 import 'package:cw_core/node.dart';
-import 'package:cw_core/pending_transaction.dart';
 import 'package:cw_core/unspent_coins_info.dart';
 import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/wallet_credentials.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_service.dart';
 import 'package:cw_core/wallet_type.dart';
-import 'package:cw_monero/api/wallet.dart';
-import 'package:cw_monero/api/wallet_manager.dart' as monero_wallet_manager;
-import 'package:cw_monero/pending_monero_transaction.dart';
 import 'package:cw_monero/monero_wallet.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_libmonero/core/key_service.dart';
 import 'package:flutter_libmonero/core/wallet_creation_service.dart';
-import 'package:flutter_libmonero/view_model/send/output.dart';
 import 'package:flutter_libmonero/monero/monero.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:hive_test/hive_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:stackwallet/utilities/flutter_secure_storage_interface.dart';
-
 import 'package:stackwallet/services/wallets.dart';
-
-import 'dart:developer' as developer;
+import 'package:stackwallet/utilities/flutter_secure_storage_interface.dart';
 
 // TODO trim down to the minimum imports above
 
@@ -76,24 +60,29 @@ void main() async {
       dirPath: '');
   late WalletCredentials credentials;
 
-  WidgetsFlutterBinding.ensureInitialized();
-  Directory appDir = (await getApplicationDocumentsDirectory());
-  if (Platform.isIOS) {
-    appDir = (await getLibraryDirectory());
-  }
-  await Hive.close();
-  Hive.init(appDir.path);
-  Hive.registerAdapter(NodeAdapter());
-  Hive.registerAdapter(WalletInfoAdapter());
-  Hive.registerAdapter(WalletTypeAdapter());
-  Hive.registerAdapter(UnspentCoinsInfoAdapter());
-
   monero.onStartup();
-  _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
-  walletService = monero.createMoneroWalletService(_walletInfoSource);
+
+  bool hiveAdaptersRegistered = false;
 
   group("Mnemonic recovery", () {
     setUp(() async {
+      await setUpTestHive();
+      if (!hiveAdaptersRegistered) {
+        hiveAdaptersRegistered = true;
+
+        Hive.registerAdapter(NodeAdapter());
+        Hive.registerAdapter(WalletInfoAdapter());
+        Hive.registerAdapter(WalletTypeAdapter());
+        Hive.registerAdapter(UnspentCoinsInfoAdapter());
+
+        final wallets = await Hive.openBox('wallets');
+        await wallets.put('currentWalletName', name);
+
+        _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
+        walletService = monero
+            .createMoneroWalletService(_walletInfoSource as Box<WalletInfo>);
+      }
+
       try {
         // if (name?.isEmpty ?? true) {
         // name = await generateName();

--- a/test/services/coins/wownero/wownero_wallet_test.dart
+++ b/test/services/coins/wownero/wownero_wallet_test.dart
@@ -122,6 +122,18 @@ void main() async {
       expect(hasThrown, false);
     });
 
+    test("Test address validation", () async { // TODO I'd like to refactor/separate this out so I can test addresses alone, without having to first create a wallet.
+      final wallet = await _walletCreationService.restoreFromSeed(credentials);
+      walletBase = wallet as WowneroWalletBase;
+
+      expect(
+          await walletBase!.validateAddress(''), false);
+      expect(
+          await walletBase!.validateAddress('Wo3jmHvTMLwE6h29fpgcb8PbJSpaKuqM7XTXVfiiu8bLCZsJvrQCbQSJR48Vo3BWNQKsMsXZ4VixndXTH25QtorC27NCjmsEi'), true);
+      expect(
+          await walletBase!.validateAddress('WasdfHvTMLwE6h29fpgcb8PbJSpaKuqM7XTXVfiiu8bLCZsJvrQCbQSJR48Vo3BWNQKsMsXZ4VixndXTH25QtorC27NCjmjkl'), false);
+    });
+
     test("Wownero 14 word seed address generation", () async {
       final wallet = await _walletCreationService.create(credentials);
       // TODO validate mnemonic

--- a/test/services/coins/wownero/wownero_wallet_test.dart
+++ b/test/services/coins/wownero/wownero_wallet_test.dart
@@ -1,38 +1,26 @@
-import 'dart:async';
 import 'dart:core';
 import 'dart:core' as core;
 import 'dart:io';
 import 'dart:math';
 
-import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
-import 'package:hive_test/hive_test.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
-
-import 'package:cw_core/monero_amount_format.dart';
 import 'package:cw_core/node.dart';
-import 'package:cw_core/pending_transaction.dart';
 import 'package:cw_core/unspent_coins_info.dart';
 import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/wallet_credentials.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_service.dart';
 import 'package:cw_core/wallet_type.dart';
-import 'package:cw_wownero/api/wallet.dart';
-import 'package:cw_wownero/pending_wownero_transaction.dart';
 import 'package:cw_wownero/wownero_wallet.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_libmonero/core/key_service.dart';
 import 'package:flutter_libmonero/core/wallet_creation_service.dart';
-import 'package:flutter_libmonero/view_model/send/output.dart';
 import 'package:flutter_libmonero/wownero/wownero.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:stackwallet/utilities/flutter_secure_storage_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:hive_test/hive_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:stackwallet/utilities/flutter_secure_storage_interface.dart';
 
 import 'wownero_wallet_test_data.dart';
 
@@ -67,24 +55,29 @@ void main() async {
       dirPath: '');
   late WalletCredentials credentials;
 
-  WidgetsFlutterBinding.ensureInitialized();
-  Directory appDir = (await getApplicationDocumentsDirectory());
-  if (Platform.isIOS) {
-    appDir = (await getLibraryDirectory());
-  }
-  await Hive.close();
-  Hive.init(appDir.path);
-  Hive.registerAdapter(NodeAdapter());
-  Hive.registerAdapter(WalletInfoAdapter());
-  Hive.registerAdapter(WalletTypeAdapter());
-  Hive.registerAdapter(UnspentCoinsInfoAdapter());
-
   wownero.onStartup();
-  _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
-  walletService = wownero.createWowneroWalletService(_walletInfoSource);
+
+  bool hiveAdaptersRegistered = false;
 
   group("Wownero 14 word seed generation", () {
     setUp(() async {
+      await setUpTestHive();
+      if (!hiveAdaptersRegistered) {
+        hiveAdaptersRegistered = true;
+
+        Hive.registerAdapter(NodeAdapter());
+        Hive.registerAdapter(WalletInfoAdapter());
+        Hive.registerAdapter(WalletTypeAdapter());
+        Hive.registerAdapter(UnspentCoinsInfoAdapter());
+
+        final wallets = await Hive.openBox('wallets');
+        await wallets.put('currentWalletName', name);
+
+        _walletInfoSource = await Hive.openBox<WalletInfo>(WalletInfo.boxName);
+        walletService = wownero
+            .createWowneroWalletService(_walletInfoSource as Box<WalletInfo>);
+      }
+
       bool hasThrown = false;
       try {
         name = 'namee${Random().nextInt(10000000)}';


### PR DESCRIPTION
Exposes `validate_address` and uses `addressValid` to determine if addresses are valid.  Adds unit tests to Monero and Wownero testing basic address types (*eg.* empty, valid, invalid, wrong nettype, wrong prefix)