### PR TITLE
Initial Linux Dockerfile

### DIFF
--- a/dockerfile.linux
+++ b/dockerfile.linux
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04 as base
+COPY . /stack_wallet
+WORKDIR /stack_wallet/scripts/linux
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y git=1:2.25.1-1ubuntu3.6 make=4.2.1-1.2 curl=7.68.0-1ubuntu2.14 cargo=0.62.0ubuntu0libgit2-0ubuntu0.20.04.1 \
+    file=1:5.38-4 ca-certificates=20211016~20.04.1 cmake=3.16.3-1ubuntu1.20.04.1 cmake-data=3.16.3-1ubuntu1.20.04.1 g++=4:9.3.0-1ubuntu2 libgmp-dev=2:6.2.0+dfsg-4ubuntu0.1 libssl-dev=1.1.1f-1ubuntu2.16 libclang-dev=1:10.0-50~exp1 \
+    unzip=6.0-25ubuntu1.1 python3=3.8.2-0ubuntu2 pkg-config=0.29.1-0ubuntu4 libglib2.0-dev=2.64.6-1~ubuntu20.04.4 libgcrypt20-dev=1.8.5-5ubuntu1.1 gettext-base=0.19.8.1-10build1 libgirepository1.0-dev=1.64.1-1~ubuntu20.04.1 \
+    valac=0.48.6-0ubuntu1 xsltproc=1.1.34-4ubuntu0.20.04.1 docbook-xsl=1.79.1+dfsg-2 python3-pip=20.0.2-5ubuntu1.6 ninja-build=1.10.0-1build1 clang=1:10.0-50~exp1 libgtk-3-dev=3.24.20-0ubuntu1.1 \
+    libunbound-dev=1.9.4-2ubuntu1.4 libzmq3-dev=4.3.2-2ubuntu1 libtool=2.4.6-14 autoconf=2.69-11.1 automake=1:1.16.1-4ubuntu6 bison=2:3.5.1+dfsg-1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install --upgrade meson==0.64.1 markdown==3.4.1 markupsafe==2.1.1 jinja2==3.1.2 pygments==2.13.0 toml==0.10.2 typogrify==2.0.7 tomli==2.0.1 && cd .. && ./prebuild.sh && cd linux && ./build_all.sh
+WORKDIR /
+RUN git clone https://github.com/flutter/flutter.git -b 3.3.4
+ENV PATH "$PATH:/flutter/bin"
+WORKDIR /stack_wallet
+RUN flutter pub get Linux && flutter build linux
+ENTRYPOINT ["/bin/bash"]

--- a/scripts/linux/build_all.sh
+++ b/scripts/linux/build_all.sh
@@ -4,7 +4,7 @@
 # flutter-elinux clean
 # flutter-elinux pub get
 # flutter-elinux build linux --dart-define="IS_ARM=true"
-mkdir build
+mkdir -p build
 ./build_secure_storage_deps.sh &
 (cd ../../crypto_plugins/flutter_liblelantus/scripts/linux && ./build_all.sh ) &
 (cd ../../crypto_plugins/flutter_libepiccash/scripts/linux && ./build_all.sh )  &

--- a/scripts/linux/build_secure_storage_deps.sh
+++ b/scripts/linux/build_secure_storage_deps.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 LINUX_DIRECTORY=$(pwd)
+JSONCPP_TAG=1.7.4
 mkdir -p build
 
 # Build JsonCPP
-cd build || exit
+cd build || exit 1
 if ! [ -x "$(command -v git)" ]; then
   echo 'Error: git is not installed.' >&2
   exit 1
 fi
-git -C jsoncpp pull || git clone https://github.com/open-source-parsers/jsoncpp.git jsoncpp
-cd jsoncpp || exit
-git checkout 1.7.4
+git -C jsoncpp pull origin $JSONCPP_TAG || git clone https://github.com/open-source-parsers/jsoncpp.git jsoncpp
+cd jsoncpp || exit 1
+git checkout $JSONCPP_TAG
 mkdir -p build
-cd build || exit
+cd build || exit 1
 cmake -DCMAKE_BUILD_TYPE=release -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=ON -DARCHIVE_INSTALL_DIR=. -G "Unix Makefiles" ..
 make -j"$(nproc)"
 
-cd "$LINUX_DIRECTORY" || exit
+cd "$LINUX_DIRECTORY" || exit 1
 # Build libSecret
 # sudo apt install meson libgirepository1.0-dev valac xsltproc gi-docgen docbook-xsl
 # sudo apt install python3-pip
 #pip3 install --user meson markdown tomli --upgrade
 # pip3 install --user gi-docgen
-cd build || exit
+cd build || exit 1
 git -C libsecret pull || git clone https://gitlab.gnome.org/GNOME/libsecret.git libsecret
-cd libsecret || exit
+cd libsecret || exit 1
 if ! [ -x "$(command -v meson)" ]; then
   echo 'Error: meson is not installed.' >&2
   exit 1


### PR DESCRIPTION
Here's an initial Dockerfile for building the x86_64 Linux "desktop" version. You'll need to run it and docker cp the /stack_wallet/build/linux/x64/release/bundle/ directory out of the container, or set your DISPLAY/XAUTH/xhost up to allow x11 connections from the container. Your wallets will be in the ephemeral container's ~/.stackwallet if you don't bind mount a volume. 

I will fix all this, but wanted to provide something now that will build the linux desktop version consistently.