### PR TITLE
Detect and handle all changes to Epic Cash send view address input on desktop and mobile

### DIFF
--- a/lib/pages/send_view/send_view.dart
+++ b/lib/pages/send_view/send_view.dart
@@ -580,6 +580,21 @@ class _SendViewState extends ConsumerState<SendView> {
       });
     }
 
+    if (coin == Coin.epicCash) {
+      sendToController.addListener(() {
+        _address = sendToController.text;
+
+        if (_address != null && _address!.isNotEmpty) {
+          _address = _address!.trim();
+          if (_address!.contains("\n")) {
+            _address = _address!.substring(0, _address!.indexOf("\n"));
+          }
+
+          sendToController.text = httpXOREpicBox(_address!);
+        }
+      });
+    }
+
     return Background(
       child: Scaffold(
         backgroundColor: Theme.of(context).extension<StackColors>()!.background,
@@ -904,6 +919,13 @@ class _SendViewState extends ConsumerState<SendView> {
                                                                     "\n"));
                                                       }
 
+                                                      if (coin ==
+                                                          Coin.epicCash) {
+                                                        // strip http:// and https:// if content contains @
+                                                        content =
+                                                            httpXOREpicBox(
+                                                                content);
+                                                      }
                                                       sendToController.text =
                                                           content;
                                                       _address = content;
@@ -1753,4 +1775,15 @@ class _SendViewState extends ConsumerState<SendView> {
       ),
     );
   }
+}
+
+// strip http:// and https:// if epicAddress contains @
+String httpXOREpicBox(String epicAddress) {
+  if ((epicAddress.startsWith("http://") ||
+          epicAddress.startsWith("https://")) &&
+      epicAddress.contains("@")) {
+    epicAddress = epicAddress.replaceAll("http://", "");
+    epicAddress = epicAddress.replaceAll("https://", "");
+  }
+  return epicAddress;
 }

--- a/lib/pages/send_view/send_view.dart
+++ b/lib/pages/send_view/send_view.dart
@@ -580,6 +580,7 @@ class _SendViewState extends ConsumerState<SendView> {
       });
     }
 
+    // add listener for epic cash to strip http:// and https:// prefixes if the address also ocntains an @ symbol (indicating an epicbox address)
     if (coin == Coin.epicCash) {
       sendToController.addListener(() {
         _address = sendToController.text;

--- a/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_send.dart
+++ b/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_send.dart
@@ -578,6 +578,11 @@ class _DesktopSendState extends ConsumerState<DesktopSend> {
         content = content.substring(0, content.indexOf("\n"));
       }
 
+      if (coin == Coin.epicCash) {
+        // strip http:// and https:// if content contains @
+        content = httpXOREpicBox(content);
+      }
+
       sendToController.text = content;
       _address = content;
 
@@ -741,6 +746,22 @@ class _DesktopSendState extends ConsumerState<DesktopSend> {
         .select((value) => value.getManagerProvider(walletId)));
     final String locale = ref.watch(
         localeServiceChangeNotifierProvider.select((value) => value.locale));
+
+    // add listener for epic cash to strip http:// and https:// prefixes if the address also ocntains an @ symbol (indicating an epicbox address)
+    if (coin == Coin.epicCash) {
+      sendToController.addListener(() {
+        _address = sendToController.text;
+
+        if (_address != null && _address!.isNotEmpty) {
+          _address = _address!.trim();
+          if (_address!.contains("\n")) {
+            _address = _address!.substring(0, _address!.indexOf("\n"));
+          }
+
+          sendToController.text = httpXOREpicBox(_address!);
+        }
+      });
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1322,4 +1343,15 @@ class _DesktopSendState extends ConsumerState<DesktopSend> {
       ],
     );
   }
+}
+
+// strip http:// and https:// if epicAddress contains @
+String httpXOREpicBox(String epicAddress) {
+  if ((epicAddress.startsWith("http://") ||
+          epicAddress.startsWith("https://")) &&
+      epicAddress.contains("@")) {
+    epicAddress = epicAddress.replaceAll("http://", "");
+    epicAddress = epicAddress.replaceAll("https://", "");
+  }
+  return epicAddress;
 }


### PR DESCRIPTION
Adds a new listener to the send view address for Epic Cash on mobile and desktop to detect all changes to it, including OS pastes

Strips http:// and https:// substrings if the address contains an @ symbol