### PR TITLE
Update bitcoin block explorers to use mempool.space

### DIFF
--- a/lib/utilities/block_explorers.dart
+++ b/lib/utilities/block_explorers.dart
@@ -6,13 +6,13 @@ Uri getBlockExplorerTransactionUrlFor({
 }) {
   switch (coin) {
     case Coin.bitcoin:
-      return Uri.parse("https://chain.so/tx/BTC/$txid");
+      return Uri.parse("https://mempool.space/tx/$txid");
     case Coin.litecoin:
       return Uri.parse("https://chain.so/tx/LTC/$txid");
     case Coin.litecoinTestNet:
       return Uri.parse("https://chain.so/tx/LTCTEST/$txid");
     case Coin.bitcoinTestNet:
-      return Uri.parse("https://chain.so/tx/BTCTEST/$txid");
+      return Uri.parse("https://mempool.space/testnet/tx/$txid");
     case Coin.dogecoin:
       return Uri.parse("https://chain.so/tx/DOGE/$txid");
     case Coin.dogecoinTestNet:


### PR DESCRIPTION
[mempool.space](https://mempool.space/) is a highly informative bitcoin block explorer with advanced features and a very clean UI. This PR swaps out the chain.so block explorer with mempool.space for both mainnet and testnet bitcoin.