### PR TITLE
Allow seed words length selection and mnemonic passphrase for new wallets on select coins

### DIFF
--- a/lib/pages/add_wallet_views/name_your_wallet_view/name_your_wallet_view.dart
+++ b/lib/pages/add_wallet_views/name_your_wallet_view/name_your_wallet_view.dart
@@ -361,6 +361,7 @@ class _NameYourWalletViewState extends ConsumerState<NameYourWalletView> {
                                     .read(mnemonicWordCountStateProvider.state)
                                     .state =
                                 Constants.possibleLengthsForCoin(coin).last;
+                            ref.read(pNewWalletOptions.notifier).state = null;
 
                             switch (widget.addWalletType) {
                               case AddWalletType.New:

--- a/lib/pages/add_wallet_views/name_your_wallet_view/name_your_wallet_view.dart
+++ b/lib/pages/add_wallet_views/name_your_wallet_view/name_your_wallet_view.dart
@@ -14,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:stackwallet/notifications/show_flush_bar.dart';
 import 'package:stackwallet/pages/add_wallet_views/create_or_restore_wallet_view/sub_widgets/coin_image.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/restore_wallet_view/restore_options_view/restore_options_view.dart';
 import 'package:stackwallet/pages_desktop_specific/my_stack_view/exit_to_my_stack_button.dart';
@@ -336,46 +337,59 @@ class _NameYourWalletViewState extends ConsumerState<NameYourWalletView> {
                           ref.read(walletsServiceChangeNotifierProvider);
                       final name = textEditingController.text;
 
-                      if (await walletsService.checkForDuplicate(name)) {
-                        unawaited(showFloatingFlushBar(
-                          type: FlushBarType.warning,
-                          message: "Wallet name already in use.",
-                          iconAsset: Assets.svg.circleAlert,
-                          context: context,
-                        ));
-                      } else {
-                        // hide keyboard if has focus
-                        if (FocusScope.of(context).hasFocus) {
-                          FocusScope.of(context).unfocus();
-                          await Future<void>.delayed(
-                              const Duration(milliseconds: 50));
-                        }
+                      final hasDuplicateName =
+                          await walletsService.checkForDuplicate(name);
 
-                        if (mounted) {
-                          switch (widget.addWalletType) {
-                            case AddWalletType.New:
-                              unawaited(Navigator.of(context).pushNamed(
-                                NewWalletRecoveryPhraseWarningView.routeName,
-                                arguments: Tuple2(
-                                  name,
-                                  coin,
-                                ),
-                              ));
-                              break;
-                            case AddWalletType.Restore:
-                              ref
-                                  .read(mnemonicWordCountStateProvider.state)
-                                  .state = Constants.possibleLengthsForCoin(
-                                      coin)
-                                  .first;
-                              unawaited(Navigator.of(context).pushNamed(
-                                RestoreOptionsView.routeName,
-                                arguments: Tuple2(
-                                  name,
-                                  coin,
-                                ),
-                              ));
-                              break;
+                      if (mounted) {
+                        if (hasDuplicateName) {
+                          unawaited(showFloatingFlushBar(
+                            type: FlushBarType.warning,
+                            message: "Wallet name already in use.",
+                            iconAsset: Assets.svg.circleAlert,
+                            context: context,
+                          ));
+                        } else {
+                          // hide keyboard if has focus
+                          if (FocusScope.of(context).hasFocus) {
+                            FocusScope.of(context).unfocus();
+                            await Future<void>.delayed(
+                                const Duration(milliseconds: 50));
+                          }
+
+                          if (mounted) {
+                            ref
+                                    .read(mnemonicWordCountStateProvider.state)
+                                    .state =
+                                Constants.possibleLengthsForCoin(coin).last;
+
+                            switch (widget.addWalletType) {
+                              case AddWalletType.New:
+                                unawaited(
+                                  Navigator.of(context).pushNamed(
+                                    coin.hasMnemonicPassphraseSupport
+                                        ? NewWalletOptionsView.routeName
+                                        : NewWalletRecoveryPhraseWarningView
+                                            .routeName,
+                                    arguments: Tuple2(
+                                      name,
+                                      coin,
+                                    ),
+                                  ),
+                                );
+                                break;
+
+                              case AddWalletType.Restore:
+                                unawaited(
+                                  Navigator.of(context).pushNamed(
+                                    RestoreOptionsView.routeName,
+                                    arguments: Tuple2(
+                                      name,
+                                      coin,
+                                    ),
+                                  ),
+                                );
+                                break;
+                            }
                           }
                         }
                       }

--- a/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
+++ b/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
@@ -112,7 +112,7 @@ class _NewWalletOptionsViewState extends ConsumerState<NewWalletOptionsView> {
                       ),
                       child: IntrinsicHeight(
                         child: Padding(
-                          padding: const EdgeInsets.all(16),
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
                           child: child,
                         ),
                       ),
@@ -130,21 +130,23 @@ class _NewWalletOptionsViewState extends ConsumerState<NewWalletOptionsView> {
                 flex: 10,
               ),
             if (!Util.isDesktop)
+              const SizedBox(
+                height: 16,
+              ),
+            if (!Util.isDesktop)
               CoinImage(
                 coin: widget.coin,
                 height: 100,
                 width: 100,
               ),
-            SizedBox(
-              height: Util.isDesktop ? 0 : 16,
-            ),
-            Text(
-              "Wallet options",
-              textAlign: TextAlign.center,
-              style: Util.isDesktop
-                  ? STextStyles.desktopH2(context)
-                  : STextStyles.pageTitleH1(context),
-            ),
+            if (Util.isDesktop)
+              Text(
+                "Wallet options",
+                textAlign: TextAlign.center,
+                style: Util.isDesktop
+                    ? STextStyles.desktopH2(context)
+                    : STextStyles.pageTitleH1(context),
+              ),
             SizedBox(
               height: Util.isDesktop ? 32 : 16,
             ),

--- a/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
+++ b/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
@@ -288,9 +288,8 @@ class _NewWalletOptionsViewState extends ConsumerState<NewWalletOptionsView> {
                   RoundedWhiteContainer(
                     child: Center(
                       child: Text(
-                        "You may protect the wallet seed with an optional passphrase. "
-                        "If you lose this passphrase you will not be able "
-                        "to restore using just your seed words.",
+                        "You may add a BIP39 passphrase. This is optional. "
+                        "You will need BOTH you seed and your passphrase to recover the wallet.",
                         style: Util.isDesktop
                             ? STextStyles.desktopTextExtraSmall(context)
                                 .copyWith(
@@ -322,7 +321,7 @@ class _NewWalletOptionsViewState extends ConsumerState<NewWalletOptionsView> {
                       enableSuggestions: false,
                       autocorrect: false,
                       decoration: standardInputDecoration(
-                        "Recovery phrase password",
+                        "BIP39 passphrase",
                         passwordFocusNode,
                         context,
                       ).copyWith(

--- a/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
+++ b/lib/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart
@@ -1,0 +1,409 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:stackwallet/pages/add_wallet_views/create_or_restore_wallet_view/sub_widgets/coin_image.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart';
+import 'package:stackwallet/pages/add_wallet_views/restore_wallet_view/restore_options_view/sub_widgets/mobile_mnemonic_length_selector.dart';
+import 'package:stackwallet/pages/add_wallet_views/restore_wallet_view/sub_widgets/mnemonic_word_count_select_sheet.dart';
+import 'package:stackwallet/pages_desktop_specific/my_stack_view/exit_to_my_stack_button.dart';
+import 'package:stackwallet/providers/ui/verify_recovery_phrase/mnemonic_word_count_state_provider.dart';
+import 'package:stackwallet/themes/stack_colors.dart';
+import 'package:stackwallet/utilities/assets.dart';
+import 'package:stackwallet/utilities/constants.dart';
+import 'package:stackwallet/utilities/enums/coin_enum.dart';
+import 'package:stackwallet/utilities/text_styles.dart';
+import 'package:stackwallet/utilities/util.dart';
+import 'package:stackwallet/widgets/background.dart';
+import 'package:stackwallet/widgets/conditional_parent.dart';
+import 'package:stackwallet/widgets/custom_buttons/app_bar_icon_button.dart';
+import 'package:stackwallet/widgets/desktop/desktop_app_bar.dart';
+import 'package:stackwallet/widgets/desktop/desktop_scaffold.dart';
+import 'package:stackwallet/widgets/desktop/primary_button.dart';
+import 'package:stackwallet/widgets/rounded_white_container.dart';
+import 'package:stackwallet/widgets/stack_text_field.dart';
+import 'package:tuple/tuple.dart';
+
+final pNewWalletOptions =
+    StateProvider<({String mnemonicPassphrase, int mnemonicWordsCount})?>(
+        (ref) => null);
+
+enum NewWalletOptions {
+  Default,
+  Advanced;
+}
+
+class NewWalletOptionsView extends ConsumerStatefulWidget {
+  const NewWalletOptionsView({
+    Key? key,
+    required this.walletName,
+    required this.coin,
+  }) : super(key: key);
+
+  static const routeName = "/newWalletOptionsView";
+
+  final String walletName;
+  final Coin coin;
+
+  @override
+  ConsumerState<NewWalletOptionsView> createState() =>
+      _NewWalletOptionsViewState();
+}
+
+class _NewWalletOptionsViewState extends ConsumerState<NewWalletOptionsView> {
+  late final FocusNode passwordFocusNode;
+  late final TextEditingController passwordController;
+
+  bool hidePassword = true;
+  NewWalletOptions _selectedOptions = NewWalletOptions.Default;
+
+  @override
+  void initState() {
+    passwordController = TextEditingController();
+    passwordFocusNode = FocusNode();
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    passwordFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lengths = Constants.possibleLengthsForCoin(widget.coin).toList();
+    return ConditionalParent(
+      condition: Util.isDesktop,
+      builder: (child) => DesktopScaffold(
+        background: Theme.of(context).extension<StackColors>()!.background,
+        appBar: const DesktopAppBar(
+          isCompactHeight: false,
+          leading: AppBarBackButton(),
+          trailing: ExitToMyStackButton(),
+        ),
+        body: SizedBox(
+          width: 480,
+          child: child,
+        ),
+      ),
+      child: ConditionalParent(
+        condition: !Util.isDesktop,
+        builder: (child) => Background(
+          child: Scaffold(
+            backgroundColor:
+                Theme.of(context).extension<StackColors>()!.background,
+            appBar: AppBar(
+              leading: const AppBarBackButton(),
+              title: Text(
+                "Wallet Options",
+                style: STextStyles.navBarTitle(context),
+              ),
+            ),
+            body: SafeArea(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return SingleChildScrollView(
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: IntrinsicHeight(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: child,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+        child: Column(
+          children: [
+            if (Util.isDesktop)
+              const Spacer(
+                flex: 10,
+              ),
+            if (!Util.isDesktop)
+              CoinImage(
+                coin: widget.coin,
+                height: 100,
+                width: 100,
+              ),
+            SizedBox(
+              height: Util.isDesktop ? 0 : 16,
+            ),
+            Text(
+              "Wallet options",
+              textAlign: TextAlign.center,
+              style: Util.isDesktop
+                  ? STextStyles.desktopH2(context)
+                  : STextStyles.pageTitleH1(context),
+            ),
+            SizedBox(
+              height: Util.isDesktop ? 32 : 16,
+            ),
+            DropdownButtonHideUnderline(
+              child: DropdownButton2<NewWalletOptions>(
+                value: _selectedOptions,
+                items: [
+                  ...NewWalletOptions.values.map(
+                    (e) => DropdownMenuItem(
+                      value: e,
+                      child: Text(
+                        e.name,
+                        style: STextStyles.desktopTextMedium(context),
+                      ),
+                    ),
+                  ),
+                ],
+                onChanged: (value) {
+                  if (value is NewWalletOptions) {
+                    setState(() {
+                      _selectedOptions = value;
+                    });
+                  }
+                },
+                isExpanded: true,
+                iconStyleData: IconStyleData(
+                  icon: SvgPicture.asset(
+                    Assets.svg.chevronDown,
+                    width: 12,
+                    height: 6,
+                    color: Theme.of(context)
+                        .extension<StackColors>()!
+                        .textFieldActiveSearchIconRight,
+                  ),
+                ),
+                dropdownStyleData: DropdownStyleData(
+                  offset: const Offset(0, -10),
+                  elevation: 0,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context)
+                        .extension<StackColors>()!
+                        .textFieldDefaultBG,
+                    borderRadius: BorderRadius.circular(
+                      Constants.size.circularBorderRadius,
+                    ),
+                  ),
+                ),
+                menuItemStyleData: const MenuItemStyleData(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(
+              height: 24,
+            ),
+            if (_selectedOptions == NewWalletOptions.Advanced)
+              Column(
+                children: [
+                  if (Util.isDesktop)
+                    DropdownButtonHideUnderline(
+                      child: DropdownButton2<int>(
+                        value: ref
+                            .watch(mnemonicWordCountStateProvider.state)
+                            .state,
+                        items: [
+                          ...lengths.map(
+                            (e) => DropdownMenuItem(
+                              value: e,
+                              child: Text(
+                                "$e word seed",
+                                style: STextStyles.desktopTextMedium(context),
+                              ),
+                            ),
+                          ),
+                        ],
+                        onChanged: (value) {
+                          if (value is int) {
+                            ref
+                                .read(mnemonicWordCountStateProvider.state)
+                                .state = value;
+                          }
+                        },
+                        isExpanded: true,
+                        iconStyleData: IconStyleData(
+                          icon: SvgPicture.asset(
+                            Assets.svg.chevronDown,
+                            width: 12,
+                            height: 6,
+                            color: Theme.of(context)
+                                .extension<StackColors>()!
+                                .textFieldActiveSearchIconRight,
+                          ),
+                        ),
+                        dropdownStyleData: DropdownStyleData(
+                          offset: const Offset(0, -10),
+                          elevation: 0,
+                          decoration: BoxDecoration(
+                            color: Theme.of(context)
+                                .extension<StackColors>()!
+                                .textFieldDefaultBG,
+                            borderRadius: BorderRadius.circular(
+                              Constants.size.circularBorderRadius,
+                            ),
+                          ),
+                        ),
+                        menuItemStyleData: const MenuItemStyleData(
+                          padding: EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (!Util.isDesktop)
+                    MobileMnemonicLengthSelector(
+                      chooseMnemonicLength: () {
+                        showModalBottomSheet<dynamic>(
+                          backgroundColor: Colors.transparent,
+                          context: context,
+                          shape: const RoundedRectangleBorder(
+                            borderRadius: BorderRadius.vertical(
+                              top: Radius.circular(20),
+                            ),
+                          ),
+                          builder: (_) {
+                            return MnemonicWordCountSelectSheet(
+                              lengthOptions: lengths,
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  const SizedBox(
+                    height: 24,
+                  ),
+                  RoundedWhiteContainer(
+                    child: Center(
+                      child: Text(
+                        "You may protect the wallet seed with an optional passphrase. "
+                        "If you lose this passphrase you will not be able "
+                        "to restore using just your seed words.",
+                        style: Util.isDesktop
+                            ? STextStyles.desktopTextExtraSmall(context)
+                                .copyWith(
+                                color: Theme.of(context)
+                                    .extension<StackColors>()!
+                                    .textSubtitle1,
+                              )
+                            : STextStyles.itemSubtitle(context),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(
+                      Constants.size.circularBorderRadius,
+                    ),
+                    child: TextField(
+                      key: const Key("mnemonicPassphraseFieldKey1"),
+                      focusNode: passwordFocusNode,
+                      controller: passwordController,
+                      style: Util.isDesktop
+                          ? STextStyles.desktopTextMedium(context).copyWith(
+                              height: 2,
+                            )
+                          : STextStyles.field(context),
+                      obscureText: hidePassword,
+                      enableSuggestions: false,
+                      autocorrect: false,
+                      decoration: standardInputDecoration(
+                        "Recovery phrase password",
+                        passwordFocusNode,
+                        context,
+                      ).copyWith(
+                        suffixIcon: UnconstrainedBox(
+                          child: ConditionalParent(
+                            condition: Util.isDesktop,
+                            builder: (child) => SizedBox(
+                              height: 70,
+                              child: child,
+                            ),
+                            child: Row(
+                              children: [
+                                SizedBox(
+                                  width: Util.isDesktop ? 24 : 16,
+                                ),
+                                GestureDetector(
+                                  key: const Key(
+                                      "mnemonicPassphraseFieldShowPasswordButtonKey"),
+                                  onTap: () async {
+                                    setState(() {
+                                      hidePassword = !hidePassword;
+                                    });
+                                  },
+                                  child: SvgPicture.asset(
+                                    hidePassword
+                                        ? Assets.svg.eye
+                                        : Assets.svg.eyeSlash,
+                                    color: Theme.of(context)
+                                        .extension<StackColors>()!
+                                        .textDark3,
+                                    width: Util.isDesktop ? 24 : 16,
+                                    height: Util.isDesktop ? 24 : 16,
+                                  ),
+                                ),
+                                const SizedBox(
+                                  width: 12,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            if (!Util.isDesktop) const Spacer(),
+            SizedBox(
+              height: Util.isDesktop ? 32 : 16,
+            ),
+            PrimaryButton(
+              label: "Continue",
+              onPressed: () {
+                if (_selectedOptions == NewWalletOptions.Advanced) {
+                  ref.read(pNewWalletOptions.notifier).state = (
+                    mnemonicWordsCount:
+                        ref.read(mnemonicWordCountStateProvider.state).state,
+                    mnemonicPassphrase: passwordController.text,
+                  );
+                } else {
+                  ref.read(pNewWalletOptions.notifier).state = null;
+                }
+
+                Navigator.of(context).pushNamed(
+                  NewWalletRecoveryPhraseWarningView.routeName,
+                  arguments: Tuple2(
+                    widget.walletName,
+                    widget.coin,
+                  ),
+                );
+              },
+            ),
+            if (!Util.isDesktop)
+              const SizedBox(
+                height: 16,
+              ),
+            if (Util.isDesktop)
+              const Spacer(
+                flex: 15,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart
+++ b/lib/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart
@@ -221,9 +221,7 @@ class _NewWalletRecoveryPhraseWarningViewState
                                 ),
                               ),
                               TextSpan(
-                                text:
-                                    "${Constants.defaultSeedPhraseLengthFor(coin: coin)}"
-                                    " words",
+                                text: "$seedCount words",
                                 style: STextStyles.desktopH3(context).copyWith(
                                   color: Theme.of(context)
                                       .extension<StackColors>()!

--- a/lib/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart
+++ b/lib/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_view/new_wallet_recovery_phrase_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/recovery_phrase_explanation_dialog.dart';
 import 'package:stackwallet/pages_desktop_specific/my_stack_view/exit_to_my_stack_button.dart';
@@ -38,7 +39,7 @@ import 'package:stackwallet/widgets/rounded_container.dart';
 import 'package:stackwallet/widgets/rounded_white_container.dart';
 import 'package:tuple/tuple.dart';
 
-class NewWalletRecoveryPhraseWarningView extends StatefulWidget {
+class NewWalletRecoveryPhraseWarningView extends ConsumerStatefulWidget {
   const NewWalletRecoveryPhraseWarningView({
     Key? key,
     required this.coin,
@@ -51,12 +52,12 @@ class NewWalletRecoveryPhraseWarningView extends StatefulWidget {
   final String walletName;
 
   @override
-  State<NewWalletRecoveryPhraseWarningView> createState() =>
+  ConsumerState<NewWalletRecoveryPhraseWarningView> createState() =>
       _NewWalletRecoveryPhraseWarningViewState();
 }
 
 class _NewWalletRecoveryPhraseWarningViewState
-    extends State<NewWalletRecoveryPhraseWarningView> {
+    extends ConsumerState<NewWalletRecoveryPhraseWarningView> {
   late final Coin coin;
   late final String walletName;
   late final bool isDesktop;
@@ -72,6 +73,10 @@ class _NewWalletRecoveryPhraseWarningViewState
   @override
   Widget build(BuildContext context) {
     debugPrint("BUILD: $runtimeType");
+    final options = ref.read(pNewWalletOptions.state).state;
+
+    final seedCount = options?.mnemonicWordsCount ??
+        Constants.defaultSeedPhraseLengthFor(coin: coin);
 
     return MasterScaffold(
       isDesktop: isDesktop,
@@ -172,7 +177,7 @@ class _NewWalletRecoveryPhraseWarningViewState
               child: isDesktop
                   ? Text(
                       "On the next screen you will see "
-                      "${Constants.defaultSeedPhraseLengthFor(coin: coin)} "
+                      "$seedCount "
                       "words that make up your recovery phrase.\n\nPlease "
                       "write it down. Keep it safe and never share it with "
                       "anyone. Your recovery phrase is the only way you can"
@@ -496,7 +501,24 @@ class _NewWalletRecoveryPhraseWarningViewState
 
                                     final manager = Manager(wallet);
 
-                                    await manager.initializeNew();
+                                    if (coin.hasMnemonicPassphraseSupport &&
+                                        ref
+                                                .read(pNewWalletOptions.state)
+                                                .state !=
+                                            null) {
+                                      await manager.initializeNew((
+                                        mnemonicPassphrase: ref
+                                            .read(pNewWalletOptions.state)
+                                            .state!
+                                            .mnemonicPassphrase,
+                                        wordCount: ref
+                                            .read(pNewWalletOptions.state)
+                                            .state!
+                                            .mnemonicWordsCount,
+                                      ));
+                                    } else {
+                                      await manager.initializeNew(null);
+                                    }
 
                                     // pop progress dialog
                                     if (mounted) {

--- a/lib/pages/add_wallet_views/restore_wallet_view/restore_options_view/restore_options_view.dart
+++ b/lib/pages/add_wallet_views/restore_wallet_view/restore_options_view/restore_options_view.dart
@@ -535,7 +535,7 @@ class _RestoreOptionsViewState extends ConsumerState<RestoreOptionsView> {
                             enableSuggestions: false,
                             autocorrect: false,
                             decoration: standardInputDecoration(
-                              "Recovery phrase password",
+                              "BIP39 passphrase",
                               passwordFocusNode,
                               context,
                             ).copyWith(
@@ -586,7 +586,9 @@ class _RestoreOptionsViewState extends ConsumerState<RestoreOptionsView> {
                         RoundedWhiteContainer(
                           child: Center(
                             child: Text(
-                              "If the recovery phrase you are about to restore was created with an optional passphrase you can enter it here.",
+                              "If the recovery phrase you are about to restore "
+                              "was created with an optional BIP39 passphrase "
+                              "you can enter it here.",
                               style: isDesktop
                                   ? STextStyles.desktopTextExtraSmall(context)
                                       .copyWith(

--- a/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_mnemonic_passphrase_dialog.dart
+++ b/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_mnemonic_passphrase_dialog.dart
@@ -113,7 +113,7 @@ class _VerifyMnemonicPassphraseDialogState
           children: [
             if (!Util.isDesktop)
               Text(
-                "Verify mnemonic passphrase",
+                "Verify BIP39 passphrase",
                 style: STextStyles.pageTitleH2(context),
               ),
             const SizedBox(
@@ -136,7 +136,7 @@ class _VerifyMnemonicPassphraseDialogState
                 enableSuggestions: false,
                 autocorrect: false,
                 decoration: standardInputDecoration(
-                  "Recovery phrase password",
+                  "Enter your BIP39 passphrase",
                   passwordFocusNode,
                   context,
                 ).copyWith(

--- a/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_mnemonic_passphrase_dialog.dart
+++ b/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_mnemonic_passphrase_dialog.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:stackwallet/notifications/show_flush_bar.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart';
+import 'package:stackwallet/themes/stack_colors.dart';
+import 'package:stackwallet/utilities/assets.dart';
+import 'package:stackwallet/utilities/constants.dart';
+import 'package:stackwallet/utilities/text_styles.dart';
+import 'package:stackwallet/utilities/util.dart';
+import 'package:stackwallet/widgets/conditional_parent.dart';
+import 'package:stackwallet/widgets/desktop/desktop_dialog.dart';
+import 'package:stackwallet/widgets/desktop/desktop_dialog_close_button.dart';
+import 'package:stackwallet/widgets/desktop/primary_button.dart';
+import 'package:stackwallet/widgets/desktop/secondary_button.dart';
+import 'package:stackwallet/widgets/stack_dialog.dart';
+import 'package:stackwallet/widgets/stack_text_field.dart';
+
+class VerifyMnemonicPassphraseDialog extends ConsumerStatefulWidget {
+  const VerifyMnemonicPassphraseDialog({super.key});
+
+  @override
+  ConsumerState<VerifyMnemonicPassphraseDialog> createState() =>
+      _VerifyMnemonicPassphraseDialogState();
+}
+
+class _VerifyMnemonicPassphraseDialogState
+    extends ConsumerState<VerifyMnemonicPassphraseDialog> {
+  late final FocusNode passwordFocusNode;
+  late final TextEditingController passwordController;
+
+  bool hidePassword = true;
+
+  bool _verifyLock = false;
+
+  void _verify() {
+    if (_verifyLock) {
+      return;
+    }
+    _verifyLock = true;
+
+    if (passwordController.text ==
+        ref.read(pNewWalletOptions.state).state!.mnemonicPassphrase) {
+      Navigator.of(context, rootNavigator: Util.isDesktop).pop("verified");
+    } else {
+      showFloatingFlushBar(
+        type: FlushBarType.warning,
+        message: "Passphrase does not match",
+        context: context,
+      );
+    }
+
+    _verifyLock = false;
+  }
+
+  @override
+  void initState() {
+    passwordController = TextEditingController();
+    passwordFocusNode = FocusNode();
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    passwordFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ConditionalParent(
+      condition: Util.isDesktop,
+      builder: (child) => DesktopDialog(
+        maxHeight: double.infinity,
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(
+                    left: 32,
+                  ),
+                  child: Text(
+                    "Verify mnemonic passphrase",
+                    style: STextStyles.desktopH3(context),
+                  ),
+                ),
+                const DesktopDialogCloseButton(),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                left: 32,
+                right: 32,
+                bottom: 32,
+              ),
+              child: child,
+            ),
+          ],
+        ),
+      ),
+      child: ConditionalParent(
+        condition: !Util.isDesktop,
+        builder: (child) => StackDialogBase(
+          keyboardPaddingAmount: MediaQuery.of(context).viewInsets.bottom,
+          child: child,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (!Util.isDesktop)
+              Text(
+                "Verify mnemonic passphrase",
+                style: STextStyles.pageTitleH2(context),
+              ),
+            const SizedBox(
+              height: 24,
+            ),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(
+                Constants.size.circularBorderRadius,
+              ),
+              child: TextField(
+                key: const Key("mnemonicPassphraseFieldKey1"),
+                focusNode: passwordFocusNode,
+                controller: passwordController,
+                style: Util.isDesktop
+                    ? STextStyles.desktopTextMedium(context).copyWith(
+                        height: 2,
+                      )
+                    : STextStyles.field(context),
+                obscureText: hidePassword,
+                enableSuggestions: false,
+                autocorrect: false,
+                decoration: standardInputDecoration(
+                  "Recovery phrase password",
+                  passwordFocusNode,
+                  context,
+                ).copyWith(
+                  suffixIcon: UnconstrainedBox(
+                    child: ConditionalParent(
+                      condition: Util.isDesktop,
+                      builder: (child) => SizedBox(
+                        height: 70,
+                        child: child,
+                      ),
+                      child: Row(
+                        children: [
+                          SizedBox(
+                            width: Util.isDesktop ? 24 : 16,
+                          ),
+                          GestureDetector(
+                            key: const Key(
+                                "mnemonicPassphraseFieldShowPasswordButtonKey"),
+                            onTap: () async {
+                              setState(() {
+                                hidePassword = !hidePassword;
+                              });
+                            },
+                            child: SvgPicture.asset(
+                              hidePassword
+                                  ? Assets.svg.eye
+                                  : Assets.svg.eyeSlash,
+                              color: Theme.of(context)
+                                  .extension<StackColors>()!
+                                  .textDark3,
+                              width: Util.isDesktop ? 24 : 16,
+                              height: Util.isDesktop ? 24 : 16,
+                            ),
+                          ),
+                          const SizedBox(
+                            width: 12,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              height: Util.isDesktop ? 48 : 24,
+            ),
+            ConditionalParent(
+              condition: !Util.isDesktop,
+              builder: (child) => Row(
+                children: [
+                  Expanded(
+                    child: SecondaryButton(
+                      label: "Cancel",
+                      onPressed: Navigator.of(
+                        context,
+                        rootNavigator: Util.isDesktop,
+                      ).pop,
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 16,
+                  ),
+                  Expanded(
+                    child: child,
+                  ),
+                ],
+              ),
+              child: PrimaryButton(
+                label: "Verify",
+                onPressed: _verify,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_recovery_phrase_view.dart
+++ b/lib/pages/add_wallet_views/verify_recovery_phrase_view/verify_recovery_phrase_view.dart
@@ -16,9 +16,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:stackwallet/notifications/show_flush_bar.dart';
 import 'package:stackwallet/pages/add_wallet_views/add_token_view/edit_wallet_tokens_view.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_view/new_wallet_recovery_phrase_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/select_wallet_for_token_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/verify_recovery_phrase_view/sub_widgets/word_table.dart';
+import 'package:stackwallet/pages/add_wallet_views/verify_recovery_phrase_view/verify_mnemonic_passphrase_dialog.dart';
 import 'package:stackwallet/pages/home_view/home_view.dart';
 import 'package:stackwallet/pages_desktop_specific/desktop_home_view.dart';
 import 'package:stackwallet/pages_desktop_specific/my_stack_view/exit_to_my_stack_button.dart';
@@ -98,8 +100,25 @@ class _VerifyRecoveryPhraseViewState
   //   }
   // }
 
+  Future<bool> _verifyMnemonicPassphrase() async {
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (_) => const VerifyMnemonicPassphraseDialog(),
+    );
+
+    return result == "verified";
+  }
+
   Future<void> _continue(bool isMatch) async {
     if (isMatch) {
+      if (ref.read(pNewWalletOptions.state).state != null) {
+        final passphraseVerified = await _verifyMnemonicPassphrase();
+
+        if (!passphraseVerified) {
+          return;
+        }
+      }
+
       await ref.read(walletsServiceChangeNotifierProvider).setMnemonicVerified(
             walletId: _manager.walletId,
           );

--- a/lib/route_generator.dart
+++ b/lib/route_generator.dart
@@ -27,6 +27,7 @@ import 'package:stackwallet/pages/add_wallet_views/add_token_view/edit_wallet_to
 import 'package:stackwallet/pages/add_wallet_views/add_wallet_view/add_wallet_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/create_or_restore_wallet_view/create_or_restore_wallet_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/name_your_wallet_view/name_your_wallet_view.dart';
+import 'package:stackwallet/pages/add_wallet_views/new_wallet_options/new_wallet_options_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_view/new_wallet_recovery_phrase_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/new_wallet_recovery_phrase_warning_view/new_wallet_recovery_phrase_warning_view.dart';
 import 'package:stackwallet/pages/add_wallet_views/restore_wallet_view/restore_options_view/restore_options_view.dart';
@@ -1091,6 +1092,21 @@ class RouteGenerator {
           return getRoute(
             shouldUseMaterialRoute: useMaterialPageRoute,
             builder: (_) => RestoreOptionsView(
+              walletName: args.item1,
+              coin: args.item2,
+            ),
+            settings: RouteSettings(
+              name: settings.name,
+            ),
+          );
+        }
+        return _routeError("${settings.name} invalid args: ${args.toString()}");
+
+      case NewWalletOptionsView.routeName:
+        if (args is Tuple2<String, Coin>) {
+          return getRoute(
+            shouldUseMaterialRoute: useMaterialPageRoute,
+            builder: (_) => NewWalletOptionsView(
               walletName: args.item1,
               coin: args.item2,
             ),

--- a/lib/services/coins/banano/banano_wallet.dart
+++ b/lib/services/coins/banano/banano_wallet.dart
@@ -600,7 +600,9 @@ class BananoWallet extends CoinServiceAPI with WalletCache, WalletDB {
   }
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     if ((await mnemonicString) != null || (await mnemonicPassphrase) != null) {
       throw Exception(
           "Attempted to overwrite mnemonic on generate new wallet!");

--- a/lib/services/coins/bitcoin/bitcoin_wallet.dart
+++ b/lib/services/coins/bitcoin/bitcoin_wallet.dart
@@ -1290,7 +1290,9 @@ class BitcoinWallet extends CoinServiceAPI
   bool get isConnected => _isConnected;
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("Generating new ${coin.prettyName} wallet.", level: LogLevel.Info);
 
@@ -1301,7 +1303,7 @@ class BitcoinWallet extends CoinServiceAPI
 
     await _prefs.init();
     try {
-      await _generateNewWallet();
+      await _generateNewWallet(data);
     } catch (e, s) {
       Logging.instance.log("Exception rethrown from initializeNew(): $e\n$s",
           level: LogLevel.Fatal);
@@ -1499,7 +1501,9 @@ class BitcoinWallet extends CoinServiceAPI
     }
   }
 
-  Future<void> _generateNewWallet() async {
+  Future<void> _generateNewWallet(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("IS_INTEGRATION_TEST: $integrationTestFlag", level: LogLevel.Info);
     if (!integrationTestFlag) {
@@ -1533,10 +1537,21 @@ class BitcoinWallet extends CoinServiceAPI
       throw Exception(
           "Attempted to overwrite mnemonic on generate new wallet!");
     }
+    final int strength;
+    if (data == null || data.wordCount == 12) {
+      strength = 128;
+    } else if (data.wordCount == 24) {
+      strength = 256;
+    } else {
+      throw Exception("Invalid word count");
+    }
     await _secureStore.write(
         key: '${_walletId}_mnemonic',
-        value: bip39.generateMnemonic(strength: 128));
-    await _secureStore.write(key: '${_walletId}_mnemonicPassphrase', value: "");
+        value: bip39.generateMnemonic(strength: strength));
+    await _secureStore.write(
+      key: '${_walletId}_mnemonicPassphrase',
+      value: data?.mnemonicPassphrase ?? "",
+    );
 
     // Generate and add addresses to relevant arrays
     final initialAddresses = await Future.wait([

--- a/lib/services/coins/coin_service.dart
+++ b/lib/services/coins/coin_service.dart
@@ -348,7 +348,9 @@ abstract class CoinServiceAPI {
     required int height,
   });
 
-  Future<void> initializeNew();
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  );
   Future<void> initializeExisting();
 
   Future<void> exit();

--- a/lib/services/coins/dogecoin/dogecoin_wallet.dart
+++ b/lib/services/coins/dogecoin/dogecoin_wallet.dart
@@ -1147,7 +1147,9 @@ class DogecoinWallet extends CoinServiceAPI
   bool get isConnected => _isConnected;
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("Generating new ${coin.prettyName} wallet.", level: LogLevel.Info);
 
@@ -1157,7 +1159,7 @@ class DogecoinWallet extends CoinServiceAPI
     }
     await _prefs.init();
     try {
-      await _generateNewWallet();
+      await _generateNewWallet(data);
     } catch (e, s) {
       Logging.instance.log("Exception rethrown from initializeNew(): $e\n$s",
           level: LogLevel.Fatal);
@@ -1349,7 +1351,9 @@ class DogecoinWallet extends CoinServiceAPI
     }
   }
 
-  Future<void> _generateNewWallet() async {
+  Future<void> _generateNewWallet(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("IS_INTEGRATION_TEST: $integrationTestFlag", level: LogLevel.Info);
     if (!integrationTestFlag) {
@@ -1383,12 +1387,20 @@ class DogecoinWallet extends CoinServiceAPI
       throw Exception(
           "Attempted to overwrite mnemonic on generate new wallet!");
     }
+    final int strength;
+    if (data == null || data.wordCount == 12) {
+      strength = 128;
+    } else if (data.wordCount == 24) {
+      strength = 256;
+    } else {
+      throw Exception("Invalid word count");
+    }
     await _secureStore.write(
         key: '${_walletId}_mnemonic',
-        value: bip39.generateMnemonic(strength: 128));
+        value: bip39.generateMnemonic(strength: strength));
     await _secureStore.write(
       key: '${_walletId}_mnemonicPassphrase',
-      value: "",
+      value: data?.mnemonicPassphrase ?? "",
     );
 
     // Generate and add addresses

--- a/lib/services/coins/epiccash/epiccash_wallet.dart
+++ b/lib/services/coins/epiccash/epiccash_wallet.dart
@@ -766,7 +766,9 @@ class EpicCashWallet extends CoinServiceAPI
   }
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     await _prefs.init();
     await updateNode(false);
     final mnemonic = await _getMnemonicList();
@@ -1738,7 +1740,6 @@ class EpicCashWallet extends CoinServiceAPI
       final isIncoming = (tx["tx_type"] == "TxReceived" ||
           tx["tx_type"] == "TxReceivedCancelled");
 
-
       final txn = isar_models.Transaction(
         walletId: walletId,
         txid: commitId ?? tx["id"].toString(),
@@ -1763,7 +1764,9 @@ class EpicCashWallet extends CoinServiceAPI
         otherData: tx['onChainNote'].toString(),
         inputs: [],
         outputs: [],
-        numberOfMessages: ((tx["numberOfMessages"] == null) ? 0 : tx["numberOfMessages"]) as int,
+        numberOfMessages: ((tx["numberOfMessages"] == null)
+            ? 0
+            : tx["numberOfMessages"]) as int,
       );
 
       // txn.address =

--- a/lib/services/coins/manager.dart
+++ b/lib/services/coins/manager.dart
@@ -180,7 +180,9 @@ class Manager with ChangeNotifier {
   Future<bool> testNetworkConnection() =>
       _currentWallet.testNetworkConnection();
 
-  Future<void> initializeNew() => _currentWallet.initializeNew();
+  Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      _currentWallet.initializeNew(data);
   Future<void> initializeExisting() => _currentWallet.initializeExisting();
   Future<void> recoverFromMnemonic({
     required String mnemonic,

--- a/lib/services/coins/monero/monero_wallet.dart
+++ b/lib/services/coins/monero/monero_wallet.dart
@@ -307,7 +307,9 @@ class MoneroWallet extends CoinServiceAPI with WalletCache, WalletDB {
   }
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     await _prefs.init();
 
     // this should never fail

--- a/lib/services/coins/namecoin/namecoin_wallet.dart
+++ b/lib/services/coins/namecoin/namecoin_wallet.dart
@@ -1268,7 +1268,9 @@ class NamecoinWallet extends CoinServiceAPI
   bool get isConnected => _isConnected;
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("Generating new ${coin.prettyName} wallet.", level: LogLevel.Info);
 
@@ -1279,7 +1281,7 @@ class NamecoinWallet extends CoinServiceAPI
 
     await _prefs.init();
     try {
-      await _generateNewWallet();
+      await _generateNewWallet(data);
     } catch (e, s) {
       Logging.instance.log("Exception rethrown from initializeNew(): $e\n$s",
           level: LogLevel.Fatal);
@@ -1517,7 +1519,9 @@ class NamecoinWallet extends CoinServiceAPI
     }
   }
 
-  Future<void> _generateNewWallet() async {
+  Future<void> _generateNewWallet(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     Logging.instance
         .log("IS_INTEGRATION_TEST: $integrationTestFlag", level: LogLevel.Info);
     if (!integrationTestFlag) {
@@ -1544,12 +1548,20 @@ class NamecoinWallet extends CoinServiceAPI
       throw Exception(
           "Attempted to overwrite mnemonic on generate new wallet!");
     }
+    final int strength;
+    if (data == null || data.wordCount == 12) {
+      strength = 128;
+    } else if (data.wordCount == 24) {
+      strength = 256;
+    } else {
+      throw Exception("Invalid word count");
+    }
     await _secureStore.write(
         key: '${_walletId}_mnemonic',
-        value: bip39.generateMnemonic(strength: 128));
+        value: bip39.generateMnemonic(strength: strength));
     await _secureStore.write(
       key: '${_walletId}_mnemonicPassphrase',
-      value: "",
+      value: data?.mnemonicPassphrase ?? "",
     );
 
     // Generate and add addresses to relevant arrays

--- a/lib/services/coins/nano/nano_wallet.dart
+++ b/lib/services/coins/nano/nano_wallet.dart
@@ -607,7 +607,9 @@ class NanoWallet extends CoinServiceAPI with WalletCache, WalletDB {
   }
 
   @override
-  Future<void> initializeNew() async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) async {
     if ((await mnemonicString) != null || (await mnemonicPassphrase) != null) {
       throw Exception(
           "Attempted to overwrite mnemonic on generate new wallet!");

--- a/lib/services/coins/wownero/wownero_wallet.dart
+++ b/lib/services/coins/wownero/wownero_wallet.dart
@@ -333,7 +333,10 @@ class WowneroWallet extends CoinServiceAPI with WalletCache, WalletDB {
   }
 
   @override
-  Future<void> initializeNew({int seedWordsLength = 14}) async {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data, {
+    int seedWordsLength = 14,
+  }) async {
     await _prefs.init();
 
     // this should never fail

--- a/lib/utilities/enums/coin_enum.dart
+++ b/lib/utilities/enums/coin_enum.dart
@@ -236,6 +236,35 @@ extension CoinExt on Coin {
     }
   }
 
+  bool get hasMnemonicPassphraseSupport {
+    switch (this) {
+      case Coin.bitcoin:
+      case Coin.bitcoinTestNet:
+      case Coin.litecoin:
+      case Coin.litecoinTestNet:
+      case Coin.bitcoincash:
+      case Coin.bitcoincashTestnet:
+      case Coin.dogecoin:
+      case Coin.dogecoinTestNet:
+      case Coin.firo:
+      case Coin.firoTestNet:
+      case Coin.namecoin:
+      case Coin.particl:
+      case Coin.ethereum:
+      case Coin.eCash:
+      case Coin.stellar:
+      case Coin.stellarTestnet:
+        return true;
+
+      case Coin.epicCash:
+      case Coin.monero:
+      case Coin.wownero:
+      case Coin.nano:
+      case Coin.banano:
+        return false;
+    }
+  }
+
   bool get hasBuySupport {
     switch (this) {
       case Coin.bitcoin:

--- a/lib/widgets/stack_dialog.dart
+++ b/lib/widgets/stack_dialog.dart
@@ -18,15 +18,22 @@ class StackDialogBase extends StatelessWidget {
     Key? key,
     this.child,
     this.padding = const EdgeInsets.all(24),
+    this.keyboardPaddingAmount = 0,
   }) : super(key: key);
 
   final EdgeInsets padding;
   final Widget? child;
+  final double keyboardPaddingAmount;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: EdgeInsets.only(
+        top: 16,
+        left: 16,
+        right: 16,
+        bottom: 16 + keyboardPaddingAmount,
+      ),
       child: Column(
         mainAxisAlignment:
             !Util.isDesktop ? MainAxisAlignment.end : MainAxisAlignment.center,

--- a/test/pages/send_view/send_view_test.mocks.dart
+++ b/test/pages/send_view/send_view_test.mocks.dart
@@ -1283,10 +1283,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i27.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -3062,10 +3064,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i23.Future<bool>.value(false),
       ) as _i23.Future<bool>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -3415,10 +3419,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i20.CoinServiceAPI {
         returnValueForMissingStub: _i23.Future<void>.value(),
       ) as _i23.Future<void>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),

--- a/test/screen_tests/address_book_view/subviews/add_address_book_view_screen_test.mocks.dart
+++ b/test/screen_tests/address_book_view/subviews/add_address_book_view_screen_test.mocks.dart
@@ -492,10 +492,12 @@ class MockManager extends _i1.Mock implements _i12.Manager {
         returnValue: _i9.Future<bool>.value(false),
       ) as _i9.Future<bool>);
   @override
-  _i9.Future<void> initializeNew() => (super.noSuchMethod(
+  _i9.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),

--- a/test/screen_tests/address_book_view/subviews/address_book_entry_details_view_screen_test.mocks.dart
+++ b/test/screen_tests/address_book_view/subviews/address_book_entry_details_view_screen_test.mocks.dart
@@ -453,10 +453,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/address_book_view/subviews/edit_address_book_entry_view_screen_test.mocks.dart
+++ b/test/screen_tests/address_book_view/subviews/edit_address_book_entry_view_screen_test.mocks.dart
@@ -451,10 +451,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/lockscreen_view_screen_test.mocks.dart
+++ b/test/screen_tests/lockscreen_view_screen_test.mocks.dart
@@ -771,10 +771,12 @@ class MockManager extends _i1.Mock implements _i13.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/main_view_tests/main_view_screen_testA_test.mocks.dart
+++ b/test/screen_tests/main_view_tests/main_view_screen_testA_test.mocks.dart
@@ -558,10 +558,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/main_view_tests/main_view_screen_testB_test.mocks.dart
+++ b/test/screen_tests/main_view_tests/main_view_screen_testB_test.mocks.dart
@@ -558,10 +558,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/main_view_tests/main_view_screen_testC_test.mocks.dart
+++ b/test/screen_tests/main_view_tests/main_view_screen_testC_test.mocks.dart
@@ -558,10 +558,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/onboarding/backup_key_view_screen_test.mocks.dart
+++ b/test/screen_tests/onboarding/backup_key_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/onboarding/backup_key_warning_view_screen_test.mocks.dart
+++ b/test/screen_tests/onboarding/backup_key_warning_view_screen_test.mocks.dart
@@ -556,10 +556,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/onboarding/create_pin_view_screen_test.mocks.dart
+++ b/test/screen_tests/onboarding/create_pin_view_screen_test.mocks.dart
@@ -771,10 +771,12 @@ class MockManager extends _i1.Mock implements _i13.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/onboarding/restore_wallet_view_screen_test.mocks.dart
+++ b/test/screen_tests/onboarding/restore_wallet_view_screen_test.mocks.dart
@@ -612,10 +612,12 @@ class MockManager extends _i1.Mock implements _i13.Manager {
         returnValue: _i9.Future<bool>.value(false),
       ) as _i9.Future<bool>);
   @override
-  _i9.Future<void> initializeNew() => (super.noSuchMethod(
+  _i9.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),

--- a/test/screen_tests/onboarding/verify_backup_key_view_screen_test.mocks.dart
+++ b/test/screen_tests/onboarding/verify_backup_key_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/currency_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/currency_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/network_settings_subviews/add_custom_node_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/network_settings_subviews/add_custom_node_view_screen_test.mocks.dart
@@ -540,10 +540,12 @@ class MockManager extends _i1.Mock implements _i12.Manager {
         returnValue: _i9.Future<bool>.value(false),
       ) as _i9.Future<bool>);
   @override
-  _i9.Future<void> initializeNew() => (super.noSuchMethod(
+  _i9.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/network_settings_subviews/node_details_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/network_settings_subviews/node_details_view_screen_test.mocks.dart
@@ -540,10 +540,12 @@ class MockManager extends _i1.Mock implements _i12.Manager {
         returnValue: _i9.Future<bool>.value(false),
       ) as _i9.Future<bool>);
   @override
-  _i9.Future<void> initializeNew() => (super.noSuchMethod(
+  _i9.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i9.Future<void>.value(),
         returnValueForMissingStub: _i9.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/wallet_backup_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/wallet_backup_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/wallet_settings_subviews/rescan_warning_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/wallet_settings_subviews/rescan_warning_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/wallet_settings_subviews/wallet_delete_mnemonic_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/wallet_settings_subviews/wallet_delete_mnemonic_view_screen_test.mocks.dart
@@ -556,10 +556,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_subviews/wallet_settings_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_subviews/wallet_settings_view_screen_test.mocks.dart
@@ -154,18 +154,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i7.CachedElectrumX {
             _i8.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i8.Future<Map<String, dynamic>>);
   @override
-  _i8.Future<List<String>> getUsedCoinSerials({
-    required _i9.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i8.Future<List<String>> getUsedCoinSerials({required _i9.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i8.Future<List<String>>.value(<String>[]),
       ) as _i8.Future<List<String>>);
@@ -792,10 +786,12 @@ class MockManager extends _i1.Mock implements _i15.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/settings_view/settings_view_screen_test.mocks.dart
+++ b/test/screen_tests/settings_view/settings_view_screen_test.mocks.dart
@@ -556,10 +556,12 @@ class MockManager extends _i1.Mock implements _i10.Manager {
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
   @override
-  _i7.Future<void> initializeNew() => (super.noSuchMethod(
+  _i7.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/screen_tests/transaction_subviews/transaction_search_results_view_screen_test.mocks.dart
+++ b/test/screen_tests/transaction_subviews/transaction_search_results_view_screen_test.mocks.dart
@@ -327,10 +327,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/wallet_view/confirm_send_view_screen_test.mocks.dart
+++ b/test/screen_tests/wallet_view/confirm_send_view_screen_test.mocks.dart
@@ -326,10 +326,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/wallet_view/receive_view_screen_test.mocks.dart
+++ b/test/screen_tests/wallet_view/receive_view_screen_test.mocks.dart
@@ -325,10 +325,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/wallet_view/send_view_screen_test.mocks.dart
+++ b/test/screen_tests/wallet_view/send_view_screen_test.mocks.dart
@@ -367,10 +367,12 @@ class MockManager extends _i1.Mock implements _i9.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/screen_tests/wallet_view/wallet_view_screen_test.mocks.dart
+++ b/test/screen_tests/wallet_view/wallet_view_screen_test.mocks.dart
@@ -327,10 +327,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i8.Future<bool>.value(false),
       ) as _i8.Future<bool>);
   @override
-  _i8.Future<void> initializeNew() => (super.noSuchMethod(
+  _i8.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),

--- a/test/services/coins/bitcoin/bitcoin_wallet_test.mocks.dart
+++ b/test/services/coins/bitcoin/bitcoin_wallet_test.mocks.dart
@@ -485,18 +485,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i5.CachedElectrumX {
             _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
   @override
-  _i4.Future<List<String>> getUsedCoinSerials({
-    required _i6.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i4.Future<List<String>> getUsedCoinSerials({required _i6.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i4.Future<List<String>>.value(<String>[]),
       ) as _i4.Future<List<String>>);

--- a/test/services/coins/bitcoincash/bitcoincash_wallet_test.dart
+++ b/test/services/coins/bitcoincash/bitcoincash_wallet_test.dart
@@ -626,7 +626,8 @@ void main() async {
       await Hive.openBox<dynamic>(testWalletId);
       await Hive.openBox<dynamic>(DB.boxNamePrefs);
 
-      await expectLater(() => bch?.initializeNew(), throwsA(isA<Exception>()))
+      await expectLater(
+              () => bch?.initializeNew(null), throwsA(isA<Exception>()))
           .then((_) {
         expect(secureStore.interactions, 2);
         verifyNever(client?.ping()).called(0);

--- a/test/services/coins/bitcoincash/bitcoincash_wallet_test.mocks.dart
+++ b/test/services/coins/bitcoincash/bitcoincash_wallet_test.mocks.dart
@@ -485,18 +485,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i5.CachedElectrumX {
             _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
   @override
-  _i4.Future<List<String>> getUsedCoinSerials({
-    required _i6.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i4.Future<List<String>> getUsedCoinSerials({required _i6.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i4.Future<List<String>>.value(<String>[]),
       ) as _i4.Future<List<String>>);

--- a/test/services/coins/dogecoin/dogecoin_wallet_test.dart
+++ b/test/services/coins/dogecoin/dogecoin_wallet_test.dart
@@ -483,7 +483,8 @@ void main() {
       await Hive.openBox<dynamic>(testWalletId);
       await Hive.openBox<dynamic>(DB.boxNamePrefs);
 
-      await expectLater(() => doge?.initializeNew(), throwsA(isA<Exception>()))
+      await expectLater(
+              () => doge?.initializeNew(null), throwsA(isA<Exception>()))
           .then((_) {
         expect(secureStore.interactions, 2);
         verifyNever(client?.ping()).called(0);

--- a/test/services/coins/dogecoin/dogecoin_wallet_test.mocks.dart
+++ b/test/services/coins/dogecoin/dogecoin_wallet_test.mocks.dart
@@ -485,18 +485,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i5.CachedElectrumX {
             _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
   @override
-  _i4.Future<List<String>> getUsedCoinSerials({
-    required _i6.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i4.Future<List<String>> getUsedCoinSerials({required _i6.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i4.Future<List<String>>.value(<String>[]),
       ) as _i4.Future<List<String>>);

--- a/test/services/coins/fake_coin_service_api.dart
+++ b/test/services/coins/fake_coin_service_api.dart
@@ -88,7 +88,9 @@ class FakeCoinServiceAPI extends CoinServiceAPI {
   }
 
   @override
-  Future<void> initializeNew() {
+  Future<void> initializeNew(
+    ({String mnemonicPassphrase, int wordCount})? data,
+  ) {
     // TODO: implement initializeNew
     throw UnimplementedError();
   }

--- a/test/services/coins/firo/firo_wallet_test.mocks.dart
+++ b/test/services/coins/firo/firo_wallet_test.mocks.dart
@@ -512,18 +512,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i6.CachedElectrumX {
             _i5.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i5.Future<Map<String, dynamic>>);
   @override
-  _i5.Future<List<String>> getUsedCoinSerials({
-    required _i7.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i5.Future<List<String>> getUsedCoinSerials({required _i7.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i5.Future<List<String>>.value(<String>[]),
       ) as _i5.Future<List<String>>);

--- a/test/services/coins/manager_test.mocks.dart
+++ b/test/services/coins/manager_test.mocks.dart
@@ -304,6 +304,11 @@ class MockFiroWallet extends _i1.Mock implements _i10.FiroWallet {
         ),
       ) as _i5.CachedElectrumX);
   @override
+  bool get lelantusCoinIsarRescanRequired => (super.noSuchMethod(
+        Invocation.getter(#lelantusCoinIsarRescanRequired),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get isRefreshing => (super.noSuchMethod(
         Invocation.getter(#isRefreshing),
         returnValue: false,
@@ -552,14 +557,34 @@ class MockFiroWallet extends _i1.Mock implements _i10.FiroWallet {
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
   @override
-  _i11.Future<void> initializeNew() => (super.noSuchMethod(
+  _i11.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
+          [data],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+  @override
+  _i11.Future<void> setLelantusCoinIsarRescanRequiredDone() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setLelantusCoinIsarRescanRequiredDone,
           [],
         ),
         returnValue: _i11.Future<void>.value(),
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
+  @override
+  _i11.Future<bool> firoRescanRecovery() => (super.noSuchMethod(
+        Invocation.method(
+          #firoRescanRecovery,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
   @override
   _i11.Future<void> initializeExisting() => (super.noSuchMethod(
         Invocation.method(

--- a/test/services/coins/namecoin/namecoin_wallet_test.mocks.dart
+++ b/test/services/coins/namecoin/namecoin_wallet_test.mocks.dart
@@ -485,18 +485,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i5.CachedElectrumX {
             _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
   @override
-  _i4.Future<List<String>> getUsedCoinSerials({
-    required _i6.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i4.Future<List<String>> getUsedCoinSerials({required _i6.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i4.Future<List<String>>.value(<String>[]),
       ) as _i4.Future<List<String>>);

--- a/test/services/coins/particl/particl_wallet_test.mocks.dart
+++ b/test/services/coins/particl/particl_wallet_test.mocks.dart
@@ -485,18 +485,12 @@ class MockCachedElectrumX extends _i1.Mock implements _i5.CachedElectrumX {
             _i4.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i4.Future<Map<String, dynamic>>);
   @override
-  _i4.Future<List<String>> getUsedCoinSerials({
-    required _i6.Coin? coin,
-    int? startNumber = 0,
-  }) =>
+  _i4.Future<List<String>> getUsedCoinSerials({required _i6.Coin? coin}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUsedCoinSerials,
           [],
-          {
-            #coin: coin,
-            #startNumber: startNumber,
-          },
+          {#coin: coin},
         ),
         returnValue: _i4.Future<List<String>>.value(<String>[]),
       ) as _i4.Future<List<String>>);

--- a/test/widget_tests/managed_favorite_test.mocks.dart
+++ b/test/widget_tests/managed_favorite_test.mocks.dart
@@ -1078,10 +1078,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i26.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -3056,10 +3058,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i23.Future<bool>.value(false),
       ) as _i23.Future<bool>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -3409,10 +3413,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i20.CoinServiceAPI {
         returnValueForMissingStub: _i23.Future<void>.value(),
       ) as _i23.Future<void>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),

--- a/test/widget_tests/table_view/table_view_row_test.mocks.dart
+++ b/test/widget_tests/table_view/table_view_row_test.mocks.dart
@@ -1162,10 +1162,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i28.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i22.Future<void> initializeNew() => (super.noSuchMethod(
+  _i22.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
@@ -2302,10 +2304,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i22.Future<bool>.value(false),
       ) as _i22.Future<bool>);
   @override
-  _i22.Future<void> initializeNew() => (super.noSuchMethod(
+  _i22.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
@@ -2655,10 +2659,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i19.CoinServiceAPI {
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
   @override
-  _i22.Future<void> initializeNew() => (super.noSuchMethod(
+  _i22.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),

--- a/test/widget_tests/transaction_card_test.mocks.dart
+++ b/test/widget_tests/transaction_card_test.mocks.dart
@@ -689,10 +689,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i19.Future<bool>.value(false),
       ) as _i19.Future<bool>);
   @override
-  _i19.Future<void> initializeNew() => (super.noSuchMethod(
+  _i19.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i19.Future<void>.value(),
         returnValueForMissingStub: _i19.Future<void>.value(),
@@ -1046,10 +1048,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i7.CoinServiceAPI {
         returnValueForMissingStub: _i19.Future<void>.value(),
       ) as _i19.Future<void>);
   @override
-  _i19.Future<void> initializeNew() => (super.noSuchMethod(
+  _i19.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i19.Future<void>.value(),
         returnValueForMissingStub: _i19.Future<void>.value(),
@@ -1313,6 +1317,11 @@ class MockFiroWallet extends _i1.Mock implements _i23.FiroWallet {
         ),
       ) as _i13.CachedElectrumX);
   @override
+  bool get lelantusCoinIsarRescanRequired => (super.noSuchMethod(
+        Invocation.getter(#lelantusCoinIsarRescanRequired),
+        returnValue: false,
+      ) as bool);
+  @override
   bool get isRefreshing => (super.noSuchMethod(
         Invocation.getter(#isRefreshing),
         returnValue: false,
@@ -1561,14 +1570,34 @@ class MockFiroWallet extends _i1.Mock implements _i23.FiroWallet {
         returnValueForMissingStub: _i19.Future<void>.value(),
       ) as _i19.Future<void>);
   @override
-  _i19.Future<void> initializeNew() => (super.noSuchMethod(
+  _i19.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
+          [data],
+        ),
+        returnValue: _i19.Future<void>.value(),
+        returnValueForMissingStub: _i19.Future<void>.value(),
+      ) as _i19.Future<void>);
+  @override
+  _i19.Future<void> setLelantusCoinIsarRescanRequiredDone() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setLelantusCoinIsarRescanRequiredDone,
           [],
         ),
         returnValue: _i19.Future<void>.value(),
         returnValueForMissingStub: _i19.Future<void>.value(),
       ) as _i19.Future<void>);
+  @override
+  _i19.Future<bool> firoRescanRecovery() => (super.noSuchMethod(
+        Invocation.method(
+          #firoRescanRecovery,
+          [],
+        ),
+        returnValue: _i19.Future<bool>.value(false),
+      ) as _i19.Future<bool>);
   @override
   _i19.Future<void> initializeExisting() => (super.noSuchMethod(
         Invocation.method(

--- a/test/widget_tests/wallet_card_test.mocks.dart
+++ b/test/widget_tests/wallet_card_test.mocks.dart
@@ -817,10 +817,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i24.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i21.Future<void> initializeNew() => (super.noSuchMethod(
+  _i21.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i21.Future<void>.value(),
         returnValueForMissingStub: _i21.Future<void>.value(),

--- a/test/widget_tests/wallet_info_row/sub_widgets/wallet_info_row_balance_future_test.mocks.dart
+++ b/test/widget_tests/wallet_info_row/sub_widgets/wallet_info_row_balance_future_test.mocks.dart
@@ -1072,10 +1072,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i26.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -2411,10 +2413,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i23.Future<bool>.value(false),
       ) as _i23.Future<bool>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -2764,10 +2768,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i20.CoinServiceAPI {
         returnValueForMissingStub: _i23.Future<void>.value(),
       ) as _i23.Future<void>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),

--- a/test/widget_tests/wallet_info_row/wallet_info_row_test.mocks.dart
+++ b/test/widget_tests/wallet_info_row/wallet_info_row_test.mocks.dart
@@ -1174,10 +1174,12 @@ class MockBitcoinWallet extends _i1.Mock implements _i29.BitcoinWallet {
         returnValueForMissingStub: null,
       );
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -2514,10 +2516,12 @@ class MockManager extends _i1.Mock implements _i6.Manager {
         returnValue: _i23.Future<bool>.value(false),
       ) as _i23.Future<bool>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),
@@ -2867,10 +2871,12 @@ class MockCoinServiceAPI extends _i1.Mock implements _i20.CoinServiceAPI {
         returnValueForMissingStub: _i23.Future<void>.value(),
       ) as _i23.Future<void>);
   @override
-  _i23.Future<void> initializeNew() => (super.noSuchMethod(
+  _i23.Future<void> initializeNew(
+          ({String mnemonicPassphrase, int wordCount})? data) =>
+      (super.noSuchMethod(
         Invocation.method(
           #initializeNew,
-          [],
+          [data],
         ),
         returnValue: _i23.Future<void>.value(),
         returnValueForMissingStub: _i23.Future<void>.value(),


### PR DESCRIPTION
Adds option screen on new wallet creation for select coins to allow choice of 12 or 24 word seeds as well as an optional mnemonic passphrase. If option is not set to default a dialog will pop up on seed word confirmation game that requests user enters their selected passphrase to verify it before finalizing wallet creation.