### PR TITLE
Avoid updating cryptonote wallet information until wallet has finished opening

### DIFF
--- a/lib/wallets/wallet/impl/monero_wallet.dart
+++ b/lib/wallets/wallet/impl/monero_wallet.dart
@@ -55,6 +55,7 @@ class MoneroWallet extends CryptonoteWallet with CwBasedInterface {
 
   @override
   Future<void> exitCwWallet() async {
+    walletOpen = false;
     (cwWalletBase as MoneroWalletBase?)?.onNewBlock = null;
     (cwWalletBase as MoneroWalletBase?)?.onNewTransaction = null;
     (cwWalletBase as MoneroWalletBase?)?.syncStatusChanged = null;
@@ -63,6 +64,8 @@ class MoneroWallet extends CryptonoteWallet with CwBasedInterface {
 
   @override
   Future<void> open() async {
+    walletOpen = false;
+
     String? password;
     try {
       password = await cwKeysStorage.getWalletPassword(walletName: walletId);
@@ -87,6 +90,8 @@ class MoneroWallet extends CryptonoteWallet with CwBasedInterface {
       const Duration(seconds: 193),
       (_) async => await cwWalletBase?.save(),
     );
+
+    walletOpen = true;
   }
 
   @override
@@ -152,6 +157,8 @@ class MoneroWallet extends CryptonoteWallet with CwBasedInterface {
 
   @override
   Future<void> updateTransactions() async {
+    if (!walletOpen) return;
+
     await (cwWalletBase as MoneroWalletBase?)?.updateTransactions();
     final transactions =
         (cwWalletBase as MoneroWalletBase?)?.transactionHistory?.transactions;

--- a/lib/wallets/wallet/intermediate/cryptonote_wallet.dart
+++ b/lib/wallets/wallet/intermediate/cryptonote_wallet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:stackwallet/wallets/crypto_currency/intermediate/cryptonote_currency.dart';
 import 'package:stackwallet/wallets/models/tx_data.dart';
 import 'package:stackwallet/wallets/wallet/wallet.dart';
@@ -7,7 +9,19 @@ abstract class CryptonoteWallet<T extends CryptonoteCurrency> extends Wallet<T>
     with MnemonicInterface<T> {
   CryptonoteWallet(T currency) : super(currency);
 
-  bool walletOpen = false;
+  Completer<void>? walletOpenCompleter;
+
+  void resetWalletOpenCompleter() {
+    if (walletOpenCompleter == null || walletOpenCompleter!.isCompleted) {
+      walletOpenCompleter = Completer<void>();
+    }
+  }
+
+  Future<void> waitForWalletOpen() async {
+    if (walletOpenCompleter != null && !walletOpenCompleter!.isCompleted) {
+      await walletOpenCompleter!.future;
+    }
+  }
 
   // ========== Overrides ======================================================
 

--- a/lib/wallets/wallet/intermediate/cryptonote_wallet.dart
+++ b/lib/wallets/wallet/intermediate/cryptonote_wallet.dart
@@ -7,6 +7,8 @@ abstract class CryptonoteWallet<T extends CryptonoteCurrency> extends Wallet<T>
     with MnemonicInterface<T> {
   CryptonoteWallet(T currency) : super(currency);
 
+  bool walletOpen = false;
+
   // ========== Overrides ======================================================
 
   @override

--- a/lib/wallets/wallet/wallet_mixin_interfaces/cw_based_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/cw_based_interface.dart
@@ -244,6 +244,8 @@ mixin CwBasedInterface<T extends CryptonoteCurrency> on CryptonoteWallet<T>
 
   @override
   Future<void> updateBalance() async {
+    if (!walletOpen) return;
+
     final total = await totalBalance;
     final available = await availableBalance;
 
@@ -300,6 +302,7 @@ mixin CwBasedInterface<T extends CryptonoteCurrency> on CryptonoteWallet<T>
   @override
   Future<void> exit() async {
     if (!_hasCalledExit) {
+      walletOpen = false;
       _hasCalledExit = true;
       autoSaveTimer?.cancel();
       await exitCwWallet();


### PR DESCRIPTION
TODO: Fix ephemerality of balance updates for unconfirmed funds (as in, Monero balances decrease by the amount of an unconfirmed send as expected, but after closing and re-opening wallet, unconfirmed send amount is re-added to balance until confirmed).