### PR TITLE
Fulcrum fixes: allow null and empty List responses, reconnect socket if needed, and related changes

### DIFF
--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -755,6 +755,13 @@ class ElectrumXClient {
         return {"rawtx": response["result"] as String};
       }
 
+      if (response is List && response.length == 1) {
+        response = response[0];
+        Logging.instance.log(
+            "getTransaction($txHash) returned a single-item list.",
+            level: LogLevel.Warning);
+      }
+
       if (response is! Map) {
         final String msg = "getTransaction($txHash) returned a non-Map response"
             " of type ${response.runtimeType}.";

--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -397,8 +397,8 @@ class ElectrumXClient {
 
           if (requestStrings.length > 1) {
             Logging.instance.log(
-              "Map returned instead of a list and there are ${requestStrings.length} queued.",
-              level: LogLevel.Error);
+                "Map returned instead of a list and there are ${requestStrings.length} queued.",
+                level: LogLevel.Error);
           }
           // Could throw error here.
         } else {
@@ -680,8 +680,14 @@ class ElectrumXClient {
       );
       final Map<String, List<Map<String, dynamic>>> result = {};
       for (int i = 0; i < response.length; i++) {
-        result[response[i]["id"] as String] =
-            List<Map<String, dynamic>>.from(response[i]["result"] as List);
+        if (response[i]["result"] is Map) {
+          result[response[i]["id"] as String] = [
+            response[i]["result"] as Map<String, dynamic>
+          ];
+        } else {
+          result[response[i]["id"] as String] =
+              List<Map<String, dynamic>>.from(response[i]["result"] as List);
+        }
       }
       return result;
     } catch (e) {

--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -397,7 +397,7 @@ class ElectrumXClient {
 
           if (requestStrings.length > 1) {
             Logging.instance.log(
-                "Map returned instead of a list and there are ${requestStrings.length} queued.",
+                "ElectrumXClient.batchRequest: Map returned instead of a list and there are ${requestStrings.length} queued.",
                 level: LogLevel.Error);
           }
           // Could throw error here.
@@ -770,7 +770,7 @@ class ElectrumXClient {
 
       if (response is! Map) {
         final String msg = "getTransaction($txHash) returned a non-Map response"
-            " of type ${response.runtimeType}.";
+            " of type ${response.runtimeType}.\nResponse: $response";
         Logging.instance.log(msg, level: LogLevel.Fatal);
         throw Exception(msg);
       }
@@ -1045,7 +1045,14 @@ class ElectrumXClient {
           blocks,
         ],
       );
-      return Decimal.parse(response["result"].toString());
+      try {
+        return Decimal.parse(response["result"].toString());
+      } catch (e, s) {
+        final String msg = "Error parsing fee rate.  Response: $response"
+            "\nResult: ${response["result"]}\nError: $e\nStack trace: $s";
+        Logging.instance.log(msg, level: LogLevel.Fatal);
+        throw Exception(msg);
+      }
     } catch (e) {
       rethrow;
     }

--- a/lib/electrumx_rpc/rpc.dart
+++ b/lib/electrumx_rpc/rpc.dart
@@ -83,20 +83,29 @@ class JsonRPC {
         if (!Prefs.instance.useTor) {
           if (_socket == null) {
             Logging.instance.log(
-              "JsonRPC _sendNextAvailableRequest attempted with"
-              " _socket=null on $host:$port",
+              "JsonRPC _sendNextAvailableRequest attempted with _socket=null on "
+              "$host:$port.  Attempting to reconnect.",
               level: LogLevel.Error,
             );
+
+            // Reconnect socket.
+            _connect().then((_) => _socket?.write('${req.jsonRequest}\r\n'));
+          } else {
+            // \r\n required by electrumx server
+            _socket!.write('${req.jsonRequest}\r\n');
           }
-          // \r\n required by electrumx server
-          _socket!.write('${req.jsonRequest}\r\n');
         } else {
           if (_socksSocket == null) {
             Logging.instance.log(
-              "JsonRPC _sendNextAvailableRequest attempted with"
-              " _socksSocket=null on $host:$port",
+              "JsonRPC _sendNextAvailableRequest attempted with "
+              "_socksSocket=null on $host:$port.  Attempting to reconnect.",
               level: LogLevel.Error,
             );
+
+            // Reconnect socket.
+            _connect()
+                .then((_) => _socksSocket?.write('${req.jsonRequest}\r\n'));
+            ;
           }
           // \r\n required by electrumx server
           _socksSocket?.write('${req.jsonRequest}\r\n');

--- a/lib/wallets/wallet/impl/bitcoincash_wallet.dart
+++ b/lib/wallets/wallet/impl/bitcoincash_wallet.dart
@@ -192,7 +192,7 @@ class BitcoincashWallet extends Bip39HDWallet
             addresses.addAll(prevOut.addresses);
           } catch (e, s) {
             Logging.instance.log(
-                "Error getting prevOutJson: $s\nStack trace: $s",
+                "Error getting prevOutJson: $e\nStack trace: $s",
                 level: LogLevel.Warning);
           }
         }

--- a/lib/wallets/wallet/impl/bitcoincash_wallet.dart
+++ b/lib/wallets/wallet/impl/bitcoincash_wallet.dart
@@ -133,6 +133,11 @@ class BitcoincashWallet extends Bip39HDWallet
           coin: cryptoCurrency.coin,
         );
 
+        // Check if the getTransaction result is an empty map.
+        if (tx.isEmpty) {
+          continue;
+        }
+
         // check for duplicates before adding to list
         if (allTransactions
                 .indexWhere((e) => e["txid"] == tx["txid"] as String) ==
@@ -173,6 +178,11 @@ class BitcoincashWallet extends Bip39HDWallet
             txHash: txid,
             coin: cryptoCurrency.coin,
           );
+
+          // If inputTx is empty, then continue to the next iteration.
+          if (inputTx.isEmpty) {
+            continue;
+          }
 
           try {
             final prevOutJson = Map<String, dynamic>.from(


### PR DESCRIPTION
Mostly affects Bitcoin Cash, which uses C++-based Fulcrum servers and may provide different responses than traditional Python-based ElectrumX servers.  Tested to not affect other coins--it seems to add benefit across the board, though.

The `seed blossom` testing mnemonic still presents issues.  Firo wallets can also still show unrelated errors.