### PR TITLE
Fulcrum: Allow certain null responses, handle unexpected Map and List responses

### DIFF
--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -755,6 +755,13 @@ class ElectrumXClient {
         return {"rawtx": response["result"] as String};
       }
 
+      if (response is List && response.length == 1) {
+        response = response[0];
+        Logging.instance.log(
+            "getTransaction($txHash) returned a single-item list.",
+            level: LogLevel.Warning);
+      }
+
       if (response is! Map) {
         final String msg = "getTransaction($txHash) returned a non-Map response"
             " of type ${response.runtimeType}.";

--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -397,8 +397,8 @@ class ElectrumXClient {
 
           if (requestStrings.length > 1) {
             Logging.instance.log(
-              "Map returned instead of a list and there are ${requestStrings.length} queued.",
-              level: LogLevel.Error);
+                "Map returned instead of a list and there are ${requestStrings.length} queued.",
+                level: LogLevel.Error);
           }
           // Could throw error here.
         } else {
@@ -680,8 +680,14 @@ class ElectrumXClient {
       );
       final Map<String, List<Map<String, dynamic>>> result = {};
       for (int i = 0; i < response.length; i++) {
-        result[response[i]["id"] as String] =
-            List<Map<String, dynamic>>.from(response[i]["result"] as List);
+        if (response[i]["result"] is Map) {
+          result[response[i]["id"] as String] = [
+            response[i]["result"] as Map<String, dynamic>
+          ];
+        } else {
+          result[response[i]["id"] as String] =
+              List<Map<String, dynamic>>.from(response[i]["result"] as List);
+        }
       }
       return result;
     } catch (e) {


### PR DESCRIPTION
Fulcrum, which is used by Litecoin, eCash, and Bitcoin Cash, can provide null responses which we currently treat as an error and for which we throw an error.  This PR allows certain null responses which were found to occur in testing and handles unexpected Map and List responses by wrapping or unwrapping them, as necessary.

See https://github.com/cculianu/Fulcrum/blob/d4b3fa1865fcd2d2bd93d36edb264a719282da98/src/Servers.cpp#L1987C1-L2013C2 for a Fulcrum endpoint which can return null without throwing an error.

Likho had reported an issue with making BCH txs which was introduced by these changes, so I separated all Fulcrum-specific changes from #750 into this PR and put the more innocuous (and generalized) ElectrumX changes into #752.  I was not able to reproduce the issue Likho saw, though, so this PR remains open, as it fixes restoration of Bitcoin Cash and eCash wallets with extensive Fusion history for me.