### PR TITLE
ElectrumX: reconnect sockets if needed, skip empty txs / inputs in batch processing, and add more logging

### DIFF
--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -397,8 +397,8 @@ class ElectrumXClient {
 
           if (requestStrings.length > 1) {
             Logging.instance.log(
-              "Map returned instead of a list and there are ${requestStrings.length} queued.",
-              level: LogLevel.Error);
+                "ElectrumXClient.batchRequest: Map returned instead of a list and there are ${requestStrings.length} queued.",
+                level: LogLevel.Error);
           }
           // Could throw error here.
         } else {
@@ -757,7 +757,7 @@ class ElectrumXClient {
 
       if (response is! Map) {
         final String msg = "getTransaction($txHash) returned a non-Map response"
-            " of type ${response.runtimeType}.";
+            " of type ${response.runtimeType}.\nResponse: $response";
         Logging.instance.log(msg, level: LogLevel.Fatal);
         throw Exception(msg);
       }
@@ -1032,7 +1032,14 @@ class ElectrumXClient {
           blocks,
         ],
       );
-      return Decimal.parse(response["result"].toString());
+      try {
+        return Decimal.parse(response["result"].toString());
+      } catch (e, s) {
+        final String msg = "Error parsing fee rate.  Response: $response"
+            "\nResult: ${response["result"]}\nError: $e\nStack trace: $s";
+        Logging.instance.log(msg, level: LogLevel.Fatal);
+        throw Exception(msg);
+      }
     } catch (e) {
       rethrow;
     }

--- a/lib/electrumx_rpc/rpc.dart
+++ b/lib/electrumx_rpc/rpc.dart
@@ -83,20 +83,29 @@ class JsonRPC {
         if (!Prefs.instance.useTor) {
           if (_socket == null) {
             Logging.instance.log(
-              "JsonRPC _sendNextAvailableRequest attempted with"
-              " _socket=null on $host:$port",
+              "JsonRPC _sendNextAvailableRequest attempted with _socket=null on "
+              "$host:$port.  Attempting to reconnect.",
               level: LogLevel.Error,
             );
+
+            // Reconnect socket.
+            _connect().then((_) => _socket?.write('${req.jsonRequest}\r\n'));
+          } else {
+            // \r\n required by electrumx server
+            _socket!.write('${req.jsonRequest}\r\n');
           }
-          // \r\n required by electrumx server
-          _socket!.write('${req.jsonRequest}\r\n');
         } else {
           if (_socksSocket == null) {
             Logging.instance.log(
-              "JsonRPC _sendNextAvailableRequest attempted with"
-              " _socksSocket=null on $host:$port",
+              "JsonRPC _sendNextAvailableRequest attempted with "
+              "_socksSocket=null on $host:$port.  Attempting to reconnect.",
               level: LogLevel.Error,
             );
+
+            // Reconnect socket.
+            _connect()
+                .then((_) => _socksSocket?.write('${req.jsonRequest}\r\n'));
+            ;
           }
           // \r\n required by electrumx server
           _socksSocket?.write('${req.jsonRequest}\r\n');

--- a/lib/wallets/wallet/impl/bitcoincash_wallet.dart
+++ b/lib/wallets/wallet/impl/bitcoincash_wallet.dart
@@ -192,7 +192,7 @@ class BitcoincashWallet extends Bip39HDWallet
             addresses.addAll(prevOut.addresses);
           } catch (e, s) {
             Logging.instance.log(
-                "Error getting prevOutJson: $s\nStack trace: $s",
+                "Error getting prevOutJson: $e\nStack trace: $s",
                 level: LogLevel.Warning);
           }
         }

--- a/lib/wallets/wallet/wallet_mixin_interfaces/electrumx_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/electrumx_interface.dart
@@ -828,7 +828,7 @@ mixin ElectrumXInterface<T extends Bip39HDCurrency> on Bip39HDWallet<T> {
 
             _latestHeight = chainHeight;
 
-            if (isFirstResponse) {
+            if (isFirstResponse && !completer.isCompleted) {
               // Return the chain height.
               completer.complete(chainHeight);
             }


### PR DESCRIPTION
This PR reconnects our JsonRPC socket(s) if needed, skips empty txs / inputs in batch processing (avoiding thrown errors which break the process), and adds more logging.

This PR was split from #750 to include only the low-risk, common-sense changes which don't introduce major changes to ElectrumX logic.  See #751 for those changes