### PR TITLE
Mark Spark coins used by sparkmobile lib as used, preventing double spends

### DIFF
--- a/lib/wallets/models/tx_data.dart
+++ b/lib/wallets/models/tx_data.dart
@@ -5,6 +5,7 @@ import 'package:stackwallet/models/isar/models/isar_models.dart';
 import 'package:stackwallet/models/paynym/paynym_account_lite.dart';
 import 'package:stackwallet/utilities/amount/amount.dart';
 import 'package:stackwallet/utilities/enums/fee_rate_type_enum.dart';
+import 'package:stackwallet/wallets/isar/models/spark_coin.dart';
 import 'package:tezart/tezart.dart' as tezart;
 import 'package:web3dart/web3dart.dart' as web3dart;
 
@@ -69,13 +70,7 @@ class TxData {
         bool isChange,
       })>? sparkRecipients;
   final List<TxData>? sparkMints;
-  final List<
-      ({
-        String serializedCoin,
-        String serializedCoinContext,
-        int groupId,
-        int height,
-      })>? usedCoins;
+  final List<SparkCoin>? usedSparkCoins;
 
   final TransactionV2? tempTx;
 
@@ -112,7 +107,7 @@ class TxData {
     this.tezosOperationsList,
     this.sparkRecipients,
     this.sparkMints,
-    this.usedCoins,
+    this.usedSparkCoins,
     this.tempTx,
   });
 
@@ -195,14 +190,7 @@ class TxData {
             })>?
         sparkRecipients,
     List<TxData>? sparkMints,
-    List<
-            ({
-              String serializedCoin,
-              String serializedCoinContext,
-              int groupId,
-              int height,
-            })>?
-        usedCoins,
+    List<SparkCoin>? usedSparkCoins,
     TransactionV2? tempTx,
   }) {
     return TxData(
@@ -240,7 +228,7 @@ class TxData {
       tezosOperationsList: tezosOperationsList ?? this.tezosOperationsList,
       sparkRecipients: sparkRecipients ?? this.sparkRecipients,
       sparkMints: sparkMints ?? this.sparkMints,
-      usedCoins: usedCoins ?? this.usedCoins,
+      usedSparkCoins: usedSparkCoins ?? this.usedSparkCoins,
       tempTx: tempTx ?? this.tempTx,
     );
   }
@@ -279,7 +267,7 @@ class TxData {
       'tezosOperationsList: $tezosOperationsList, '
       'sparkRecipients: $sparkRecipients, '
       'sparkMints: $sparkMints, '
-      'usedCoins: $usedCoins, '
+      'usedSparkCoins: $usedSparkCoins, '
       'tempTx: $tempTx, '
       '}';
 }

--- a/lib/wallets/models/tx_data.dart
+++ b/lib/wallets/models/tx_data.dart
@@ -69,6 +69,13 @@ class TxData {
         bool isChange,
       })>? sparkRecipients;
   final List<TxData>? sparkMints;
+  final List<
+      ({
+        String serializedCoin,
+        String serializedCoinContext,
+        int groupId,
+        int height,
+      })>? usedCoins;
 
   final TransactionV2? tempTx;
 
@@ -105,6 +112,7 @@ class TxData {
     this.tezosOperationsList,
     this.sparkRecipients,
     this.sparkMints,
+    this.usedCoins,
     this.tempTx,
   });
 
@@ -187,6 +195,14 @@ class TxData {
             })>?
         sparkRecipients,
     List<TxData>? sparkMints,
+    List<
+            ({
+              String serializedCoin,
+              String serializedCoinContext,
+              int groupId,
+              int height,
+            })>?
+        usedCoins,
     TransactionV2? tempTx,
   }) {
     return TxData(
@@ -224,6 +240,7 @@ class TxData {
       tezosOperationsList: tezosOperationsList ?? this.tezosOperationsList,
       sparkRecipients: sparkRecipients ?? this.sparkRecipients,
       sparkMints: sparkMints ?? this.sparkMints,
+      usedCoins: usedCoins ?? this.usedCoins,
       tempTx: tempTx ?? this.tempTx,
     );
   }
@@ -262,6 +279,7 @@ class TxData {
       'tezosOperationsList: $tezosOperationsList, '
       'sparkRecipients: $sparkRecipients, '
       'sparkMints: $sparkMints, '
+      'usedCoins: $usedCoins, '
       'tempTx: $tempTx, '
       '}';
 }

--- a/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
@@ -1499,6 +1499,13 @@ Future<
       Uint8List serializedSpendPayload,
       List<Uint8List> outputScripts,
       int fee,
+      List<
+          ({
+            int groupId,
+            int height,
+            String serializedCoin,
+            String serializedCoinContext
+          })> usedCoins,
     })> _createSparkSend(
     ({
       String privateKeyHex,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -674,8 +674,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
-      resolved-ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
+      ref: "5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1"
+      resolved-ref: "5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1"
       url: "https://github.com/cypherstack/flutter_libsparkmobile.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -674,8 +674,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: fb50031056fbea0326f7dd76ad59d165c1e5eee5
-      resolved-ref: fb50031056fbea0326f7dd76ad59d165c1e5eee5
+      ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
+      resolved-ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
       url: "https://github.com/cypherstack/flutter_libsparkmobile.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -674,8 +674,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1"
-      resolved-ref: "5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1"
+      ref: "3f986ca1a94bdac5d31373454c989cc2f5842de8"
+      resolved-ref: "3f986ca1a94bdac5d31373454c989cc2f5842de8"
       url: "https://github.com/cypherstack/flutter_libsparkmobile.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter_libsparkmobile:
     git:
       url: https://github.com/cypherstack/flutter_libsparkmobile.git
-      ref: 5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1
+      ref: 3f986ca1a94bdac5d31373454c989cc2f5842de8
 
   flutter_libmonero:
     path: ./crypto_plugins/flutter_libmonero

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter_libsparkmobile:
     git:
       url: https://github.com/cypherstack/flutter_libsparkmobile.git
-      ref: fb50031056fbea0326f7dd76ad59d165c1e5eee5
+      ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
 
   flutter_libmonero:
     path: ./crypto_plugins/flutter_libmonero

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter_libsparkmobile:
     git:
       url: https://github.com/cypherstack/flutter_libsparkmobile.git
-      ref: ca5c3a821b9e5fa7dfb5a3df9577caa7bdd46f11
+      ref: 5bc70bc4d8b3799a9c3d6cad0f8fe585be9de2f1
 
   flutter_libmonero:
     path: ./crypto_plugins/flutter_libmonero


### PR DESCRIPTION
 - [x] Update sparkmobile's dart_interface.cpp in flutter_libsparkmobile
 - [x] Update Dart wrapper to return usedCoins as per sparkmobile
 - [x] Match usedCoins to SparkCoins in Stack Wallet
 - [x] Update coins as used
 
Thank you @julian-CStack for your pivotal/critical contributions to this, I was doing it much clunkier and you set this process up for success well before sparkmobile enabled it

Closes #744 

 - [x] Merge https://github.com/cypherstack/flutter_libsparkmobile/pull/26 after testing and
 - [x] update pubspec.yaml to point to flutter_libsparkmobile#main before merging this PR.