### PR TITLE
Add "&all" param to Ethereum API call (addresses BEAM contract issue)

### DIFF
--- a/lib/services/ethereum/ethereum_api.dart
+++ b/lib/services/ethereum/ethereum_api.dart
@@ -612,7 +612,7 @@ abstract class EthereumAPI {
       final response = await client.get(
         url: Uri.parse(
           // "$stackBaseServer/tokens?addrs=$contractAddress&parts=all",
-          "$stackBaseServer/names?terms=$contractAddress",
+          "$stackBaseServer/names?terms=$contractAddress&all",
         ),
         proxyInfo: Prefs.instance.useTor
             ? TorService.sharedInstance.getProxyInfo()


### PR DESCRIPTION
> We are calling https://eth.stackwallet.com/names?terms=0xE5AcBB03D73267c03349c76EaD672Ee4d941F499 which returns an empty data array, if we use the "all" parameter we will get the data we need.
> 
> https://eth.stackwallet.com/names?terms=0xE5AcBB03D73267c03349c76EaD672Ee4d941F499&all
>
> That change to our request code should let the BEAM token and another other ones not in the DB that get added work

Thank you @danrmiller 