### PR TITLE
Default to using` double.parse` in `electrum_adapter`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -528,8 +528,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "2897c6448e131241d4d91fe23fdab83305134225"
-      resolved-ref: "2897c6448e131241d4d91fe23fdab83305134225"
+      ref: "9e9441fc1e9ace8907256fff05fe2c607b0933b6"
+      resolved-ref: "9e9441fc1e9ace8907256fff05fe2c607b0933b6"
       url: "https://github.com/cypherstack/electrum_adapter.git"
     source: git
     version: "3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -179,7 +179,7 @@ dependencies:
   electrum_adapter:
     git:
       url: https://github.com/cypherstack/electrum_adapter.git
-      ref: 2897c6448e131241d4d91fe23fdab83305134225
+      ref: 9e9441fc1e9ace8907256fff05fe2c607b0933b6
   stream_channel: ^2.1.0
 
 dev_dependencies:


### PR DESCRIPTION
`catch` with the original (their custom) `_parseDouble`

See https://github.com/cypherstack/electrum_adapter/issues/9