### PR TITLE
Update block_explorers.dart  (change eCash default explorer)

### DIFF
--- a/lib/utilities/block_explorers.dart
+++ b/lib/utilities/block_explorers.dart
@@ -31,7 +31,7 @@ Uri getDefaultBlockExplorerUrlFor({
     case Coin.dogecoin:
       return Uri.parse("https://chain.so/tx/DOGE/$txid");
     case Coin.eCash:
-      return Uri.parse("https://explorer.bitcoinabc.org/tx/$txid");
+      return Uri.parse("https://explorer.e.cash/tx/$txid");
     case Coin.dogecoinTestNet:
       return Uri.parse("https://chain.so/tx/DOGETEST/$txid");
     case Coin.epicCash:


### PR DESCRIPTION
Changed the eCash block explorer from bitcoinabc.org to the default explorer.e.cash.