### PR TITLE
Remove unused socks_socket package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1574,7 +1574,7 @@ packages:
     source: hosted
     version: "1.0.4"
   socks_socket:
-    dependency: "direct main"
+    dependency: transitive
     description:
       path: "."
       ref: master
@@ -1586,8 +1586,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/solana"
-      ref: "0ada1f775c2a2c815de640424270a229f5e91e2f"
-      resolved-ref: "0ada1f775c2a2c815de640424270a229f5e91e2f"
+      ref: a83e375678eb22fe544dc125d29bbec0fb833882
+      resolved-ref: a83e375678eb22fe544dc125d29bbec0fb833882
       url: "https://github.com/cypherstack/espresso-cash-public.git"
     source: git
     version: "0.30.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -157,10 +157,6 @@ dependencies:
   nanodart: ^2.0.0
   basic_utils: ^5.5.4
   stellar_flutter_sdk: ^1.5.3
-  socks_socket:
-    git:
-      url: https://github.com/cypherstack/socks_socket.git
-      ref: master
   bip340: ^0.2.0
 #  tezart: ^2.0.5
   tezart:


### PR DESCRIPTION
So the nonexistence of github.com:cypherstack/socks_socket doesn't interfere with `pub get`s

We don't use socks_socket.dart from this package, instead using it via cypherstack/tor.

Reference https://github.com/cypherstack/tor/pull/25