### PR TITLE
Update building.md for tor deps

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -62,10 +62,6 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.bashrc 
 rustup install 1.67.1 1.72.0 1.73.0
 rustup default 1.67.1
-```
-
-Install the additional components for Rust:
-```
 cargo install cargo-ndk --version 2.12.7 --locked
 ```
 
@@ -197,9 +193,9 @@ Download and install [Rust](https://www.rust-lang.org/tools/install).  [Rustup](
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.bashrc 
-rustup install 1.67.1
-rustup install 1.72.0
+rustup install 1.67.1 1.72.0 1.73.0
 rustup default 1.67.1
+cargo install cargo-ndk --version 2.12.7 --locked
 cargo install cbindgen cargo-lipo
 rustup target add aarch64-apple-ios aarch64-apple-darwin
 ```
@@ -298,17 +294,10 @@ Run `flutter doctor` in PowerShell to confirm its installation.
 ### Rust
 Install [Rust](https://www.rust-lang.org/tools/install) on the Windows host (not in WSL2).  Download the installer from [rustup.rs](https://rustup.rs), make sure it works on the commandline (you may need to open a new terminal), and install the following versions:
 ```
-rustup install 1.72.0 # For frostdart and tor.
-rustup install 1.67.1 # For flutter_libepiccash.
+rustup install 1.67.1 1.72.0 1.73.0
 rustup default 1.67.1
-```
-<!--
-You may also need to install `cargo-ndk`:
-```
-rustup install 1.73.0 # For cargo-ndk.
 cargo install cargo-ndk --version 2.12.7 --locked
 ```
--->
 
 ### Windows SDK and Developer Mode
 Install the Windows SDK: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/  You may need to install the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/), which can be installed [by Visual Studio](https://stackoverflow.com/a/73923899) (`Tools > Get Tools and Features... > Modify > Individual Components > Windows 10 SDK`).


### PR DESCRIPTION
cypherstack/tor requires cargo-ndk on Windows but this was commented.

As it's needed on the other platforms, we should list it right next to the Rust toolchains required throughout the stack.