### PR TITLE
Add defaultFeeRate per ElectrumX coin and use it if fee estimates unavailable from node

### DIFF
--- a/lib/wallets/crypto_currency/coins/bitcoin.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoin.dart
@@ -297,6 +297,6 @@ class Bitcoin extends Bip39HDCurrency
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 1000;
+  BigInt get defaultFeeRate => BigInt.from(1000);
   // https://github.com/bitcoin/bitcoin/blob/feab35189bc00bc4cf15e9dcb5cf6b34ff3a1e91/test/functional/mempool_limit.py#L259
 }

--- a/lib/wallets/crypto_currency/coins/bitcoin.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoin.dart
@@ -295,4 +295,8 @@ class Bitcoin extends Bip39HDCurrency
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 1000;
+  // https://github.com/bitcoin/bitcoin/blob/feab35189bc00bc4cf15e9dcb5cf6b34ff3a1e91/test/functional/mempool_limit.py#L259
 }

--- a/lib/wallets/crypto_currency/coins/bitcoin_frost.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoin_frost.dart
@@ -202,6 +202,7 @@ class BitcoinFrost extends FrostCurrency {
     }
   }
 
-  @override
-  int get defaultFeeRate => 1000;
+  // @override
+  BigInt get defaultFeeRate => BigInt.from(1000);
+  // https://github.com/bitcoin/bitcoin/blob/feab35189bc00bc4cf15e9dcb5cf6b34ff3a1e91/test/functional/mempool_limit.py#L259
 }

--- a/lib/wallets/crypto_currency/coins/bitcoin_frost.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoin_frost.dart
@@ -201,4 +201,7 @@ class BitcoinFrost extends FrostCurrency {
         );
     }
   }
+
+  @override
+  int get defaultFeeRate => 1000;
 }

--- a/lib/wallets/crypto_currency/coins/bitcoincash.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoincash.dart
@@ -367,4 +367,7 @@ class Bitcoincash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 2;
+
+  @override
+  int get defaultFeeRate => 1000;
 }

--- a/lib/wallets/crypto_currency/coins/bitcoincash.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoincash.dart
@@ -369,5 +369,5 @@ class Bitcoincash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 2;
 
   @override
-  int get defaultFeeRate => 1000;
+  BigInt get defaultFeeRate => BigInt.from(1000);
 }

--- a/lib/wallets/crypto_currency/coins/dogecoin.dart
+++ b/lib/wallets/crypto_currency/coins/dogecoin.dart
@@ -252,4 +252,8 @@ class Dogecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 1000000;
+  // https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
 }

--- a/lib/wallets/crypto_currency/coins/dogecoin.dart
+++ b/lib/wallets/crypto_currency/coins/dogecoin.dart
@@ -254,6 +254,6 @@ class Dogecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 1000000;
+  BigInt get defaultFeeRate => BigInt.from(1000000);
   // https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
 }

--- a/lib/wallets/crypto_currency/coins/ecash.dart
+++ b/lib/wallets/crypto_currency/coins/ecash.dart
@@ -339,4 +339,7 @@ class Ecash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 2;
+
+  @override
+  int get defaultFeeRate => 200;
 }

--- a/lib/wallets/crypto_currency/coins/ecash.dart
+++ b/lib/wallets/crypto_currency/coins/ecash.dart
@@ -341,5 +341,5 @@ class Ecash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 2;
 
   @override
-  int get defaultFeeRate => 200;
+  BigInt get defaultFeeRate => BigInt.from(200);
 }

--- a/lib/wallets/crypto_currency/coins/firo.dart
+++ b/lib/wallets/crypto_currency/coins/firo.dart
@@ -272,5 +272,5 @@ class Firo extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 1000;
+  BigInt get defaultFeeRate => BigInt.from(1000);
 }

--- a/lib/wallets/crypto_currency/coins/firo.dart
+++ b/lib/wallets/crypto_currency/coins/firo.dart
@@ -270,4 +270,7 @@ class Firo extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 1000;
 }

--- a/lib/wallets/crypto_currency/coins/litecoin.dart
+++ b/lib/wallets/crypto_currency/coins/litecoin.dart
@@ -285,5 +285,5 @@ class Litecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 1000;
+  BigInt get defaultFeeRate => BigInt.from(1000);
 }

--- a/lib/wallets/crypto_currency/coins/litecoin.dart
+++ b/lib/wallets/crypto_currency/coins/litecoin.dart
@@ -283,4 +283,7 @@ class Litecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 1000;
 }

--- a/lib/wallets/crypto_currency/coins/namecoin.dart
+++ b/lib/wallets/crypto_currency/coins/namecoin.dart
@@ -255,4 +255,7 @@ class Namecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 1000;
 }

--- a/lib/wallets/crypto_currency/coins/namecoin.dart
+++ b/lib/wallets/crypto_currency/coins/namecoin.dart
@@ -257,5 +257,5 @@ class Namecoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 1000;
+  BigInt get defaultFeeRate => BigInt.from(1000);
 }

--- a/lib/wallets/crypto_currency/coins/particl.dart
+++ b/lib/wallets/crypto_currency/coins/particl.dart
@@ -233,4 +233,7 @@ class Particl extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 1;
+
+  @override
+  int get defaultFeeRate => 20000;
 }

--- a/lib/wallets/crypto_currency/coins/particl.dart
+++ b/lib/wallets/crypto_currency/coins/particl.dart
@@ -235,5 +235,5 @@ class Particl extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 1;
 
   @override
-  int get defaultFeeRate => 20000;
+  BigInt get defaultFeeRate => BigInt.from(20000);
 }

--- a/lib/wallets/crypto_currency/coins/peercoin.dart
+++ b/lib/wallets/crypto_currency/coins/peercoin.dart
@@ -259,5 +259,5 @@ class Peercoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   int get transactionVersion => 3;
 
   @override
-  int get defaultFeeRate => 5000;
+  BigInt get defaultFeeRate => BigInt.from(5000);
 }

--- a/lib/wallets/crypto_currency/coins/peercoin.dart
+++ b/lib/wallets/crypto_currency/coins/peercoin.dart
@@ -257,4 +257,7 @@ class Peercoin extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get transactionVersion => 3;
+
+  @override
+  int get defaultFeeRate => 5000;
 }

--- a/lib/wallets/crypto_currency/interfaces/electrumx_currency_interface.dart
+++ b/lib/wallets/crypto_currency/interfaces/electrumx_currency_interface.dart
@@ -2,4 +2,7 @@ import '../intermediate/bip39_hd_currency.dart';
 
 mixin ElectrumXCurrencyInterface on Bip39HDCurrency {
   int get transactionVersion;
+
+  /// The default fee rate in satoshis per kilobyte.
+  int get defaultFeeRate;
 }

--- a/lib/wallets/crypto_currency/interfaces/electrumx_currency_interface.dart
+++ b/lib/wallets/crypto_currency/interfaces/electrumx_currency_interface.dart
@@ -4,5 +4,5 @@ mixin ElectrumXCurrencyInterface on Bip39HDCurrency {
   int get transactionVersion;
 
   /// The default fee rate in satoshis per kilobyte.
-  int get defaultFeeRate;
+  BigInt get defaultFeeRate;
 }


### PR DESCRIPTION
defaultFeeRate as used here may instead more accurately refer to the minimum (absolute) fee for relay.