### PR TITLE
Reconfigure logic for rescan to remove upper address limit

### DIFF
--- a/lib/wallets/crypto_currency/coins/bitcoincash.dart
+++ b/lib/wallets/crypto_currency/coins/bitcoincash.dart
@@ -55,8 +55,6 @@ class Bitcoincash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get maxUnusedAddressGap => 50;
-  @override
-  int get maxNumberOfIndexesToCheck => 10000000;
 
   @override
   // change this to change the number of confirms a tx needs in order to show as confirmed

--- a/lib/wallets/crypto_currency/coins/ecash.dart
+++ b/lib/wallets/crypto_currency/coins/ecash.dart
@@ -50,8 +50,6 @@ class Ecash extends Bip39HDCurrency with ElectrumXCurrencyInterface {
 
   @override
   int get maxUnusedAddressGap => 50;
-  @override
-  int get maxNumberOfIndexesToCheck => 10000000;
 
   @override
   // change this to change the number of confirms a tx needs in order to show as confirmed

--- a/lib/wallets/crypto_currency/intermediate/bip39_hd_currency.dart
+++ b/lib/wallets/crypto_currency/intermediate/bip39_hd_currency.dart
@@ -1,6 +1,7 @@
 import 'package:coinlib_flutter/coinlib_flutter.dart' as coinlib;
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
+
 import '../../../models/isar/models/blockchain_data/address.dart';
 import '../../../utilities/amount/amount.dart';
 import '../../../utilities/enums/derive_path_type_enum.dart';
@@ -16,7 +17,6 @@ abstract class Bip39HDCurrency extends Bip39Currency {
   List<DerivePathType> get supportedDerivationPathTypes;
 
   int get maxUnusedAddressGap => 50;
-  int get maxNumberOfIndexesToCheck => 10000;
 
   String constructDerivePath({
     required DerivePathType derivePathType,

--- a/lib/wallets/wallet/wallet_mixin_interfaces/electrumx_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/electrumx_interface.dart
@@ -937,8 +937,7 @@ mixin ElectrumXInterface<T extends ElectrumXCurrencyInterface>
     int highestIndexWithHistory = 0;
 
     for (int index = 0;
-        index < cryptoCurrency.maxNumberOfIndexesToCheck &&
-            gapCounter < cryptoCurrency.maxUnusedAddressGap;
+        gapCounter < cryptoCurrency.maxUnusedAddressGap;
         index += txCountBatchSize) {
       Logging.instance.log(
         "index: $index, \t GapCounter $chain ${type.name}: $gapCounter",
@@ -1017,10 +1016,7 @@ mixin ElectrumXInterface<T extends ElectrumXCurrencyInterface>
     final List<Address> addressArray = [];
     int gapCounter = 0;
     int index = 0;
-    for (;
-        index < cryptoCurrency.maxNumberOfIndexesToCheck &&
-            gapCounter < cryptoCurrency.maxUnusedAddressGap;
-        index++) {
+    for (; gapCounter < cryptoCurrency.maxUnusedAddressGap; index++) {
       Logging.instance.log(
         "index: $index, \t GapCounter chain=$chain ${type.name}: $gapCounter",
         level: LogLevel.Info,


### PR DESCRIPTION
Now we just keep scanning up until the unused activity gap is reached.
