### PR TITLE
Epic fixes

### DIFF
--- a/lib/wallets/wallet/impl/epiccash_wallet.dart
+++ b/lib/wallets/wallet/impl/epiccash_wallet.dart
@@ -609,7 +609,7 @@ class EpiccashWallet extends Bip39Wallet {
           wallet: wallet!,
           selectionStrategyIsAll: 0,
           minimumConfirmations: cryptoCurrency.minConfirms,
-          message: txData.noteOnChain!,
+          message: txData.noteOnChain ?? "",
           amount: txData.recipients!.first.amount.raw.toInt(),
           address: txData.recipients!.first.address,
         );


### PR DESCRIPTION
Merge Likho's epic-wallet#3.6.1 fixes into cypherstack/epic-wallet#master
Add cypherstack/epic-wallet as submodule to flutter_libepiccash (in rust dir)
use local epic-wallet source (by path)
Update http send code to replace unsafe/crashing `unwrap` with a `match` which returns error