### PR TITLE
feat(monero): enable local monero nodes while Tor is enabled via a "Bypass TOR" node option

### DIFF
--- a/lib/pages/settings_views/global_settings_view/manage_nodes_views/add_edit_node_view.dart
+++ b/lib/pages/settings_views/global_settings_view/manage_nodes_views/add_edit_node_view.dart
@@ -241,6 +241,8 @@ class _AddEditNodeViewState extends ConsumerState<AddEditNodeView> {
     final plainEnabled =
         formData.netOption == TorPlainNetworkOption.clear ||
         formData.netOption == TorPlainNetworkOption.both;
+    
+    final forceNoTor = formData.forceNoTor ?? false;
 
     switch (viewType) {
       case AddEditNodeViewType.add:
@@ -258,6 +260,7 @@ class _AddEditNodeViewState extends ConsumerState<AddEditNodeView> {
           isDown: false,
           torEnabled: torEnabled,
           clearnetEnabled: plainEnabled,
+          forceNoTor: forceNoTor,
         );
 
         await ref
@@ -285,6 +288,7 @@ class _AddEditNodeViewState extends ConsumerState<AddEditNodeView> {
           isDown: false,
           torEnabled: torEnabled,
           clearnetEnabled: plainEnabled,
+          forceNoTor: forceNoTor,
         );
 
         await ref
@@ -744,7 +748,7 @@ class _AddEditNodeViewState extends ConsumerState<AddEditNodeView> {
 class NodeFormData {
   String? name, host, login, password;
   int? port;
-  bool? useSSL, isFailover, trusted;
+  bool? useSSL, isFailover, trusted, forceNoTor;
   TorPlainNetworkOption? netOption;
 
   @override
@@ -793,6 +797,7 @@ class _NodeFormState extends ConsumerState<NodeForm> {
   bool _useSSL = false;
   bool _isFailover = false;
   bool _trusted = false;
+  bool _forceNoTor = false;
   int? port;
   late bool enableSSLCheckbox;
   late TorPlainNetworkOption netOption;
@@ -851,6 +856,7 @@ class _NodeFormState extends ConsumerState<NodeForm> {
     ref.read(nodeFormDataProvider).isFailover = _isFailover;
     ref.read(nodeFormDataProvider).trusted = _trusted;
     ref.read(nodeFormDataProvider).netOption = netOption;
+    ref.read(nodeFormDataProvider).forceNoTor = _forceNoTor;
   }
 
   @override
@@ -885,6 +891,7 @@ class _NodeFormState extends ConsumerState<NodeForm> {
       _useSSL = node.useSSL;
       _isFailover = node.isFailover;
       _trusted = node.trusted ?? false;
+      _forceNoTor = node.forceNoTor ?? false;
 
       if (node.torEnabled && !node.clearnetEnabled) {
         netOption = TorPlainNetworkOption.tor;
@@ -1445,8 +1452,47 @@ class _NodeFormState extends ConsumerState<NodeForm> {
               ),
             ],
           ),
+        if (widget.coin is CryptonoteCurrency && _isLocalNode())
+          const SizedBox(height: 8),
+        if (widget.coin is CryptonoteCurrency && _isLocalNode())
+          Row(
+            children: [
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: Checkbox(
+                  fillColor:
+                      !widget.readOnly
+                          ? null
+                          : MaterialStateProperty.all(
+                            Theme.of(
+                              context,
+                            ).extension<StackColors>()!.checkboxBGDisabled,
+                          ),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  value: _forceNoTor,
+                  onChanged:
+                      !widget.readOnly
+                          ? (newValue) {
+                            setState(() {
+                              _forceNoTor = newValue!;
+                            });
+                            _updateState();
+                          }
+                          : null,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text("Bypass TOR", style: STextStyles.itemSubtitle12(context)),
+            ],
+          ),
       ],
     );
+  }
+
+  bool _isLocalNode() {
+    final host = _hostController.text.toLowerCase();
+    return host.contains("127.0.0.1") || host.contains("localhost");
   }
 }
 

--- a/lib/pages/settings_views/global_settings_view/manage_nodes_views/node_details_view.dart
+++ b/lib/pages/settings_views/global_settings_view/manage_nodes_views/node_details_view.dart
@@ -320,7 +320,8 @@ class _NodeDetailsViewState extends ConsumerState<NodeDetailsView> {
                         ..login = node.loginName
                         ..port = node.port
                         ..isFailover = node.isFailover
-                        ..netOption = netOption;
+                        ..netOption = netOption
+                        ..forceNoTor = node.forceNoTor;
                       nodeFormData.password = await node.getPassword(
                         ref.read(secureStoreProvider),
                       );
@@ -396,6 +397,7 @@ class _NodeDetailsViewState extends ConsumerState<NodeDetailsView> {
                                         TorPlainNetworkOption.clear ||
                                     ref.read(nodeFormDataProvider).netOption ==
                                         TorPlainNetworkOption.both,
+                            forceNoTor: ref.read(nodeFormDataProvider).forceNoTor,
                           );
 
                           await ref

--- a/lib/wallets/wallet/intermediate/lib_monero_wallet.dart
+++ b/lib/wallets/wallet/intermediate/lib_monero_wallet.dart
@@ -520,7 +520,7 @@ abstract class LibMoneroWallet<T extends CryptonoteCurrency>
             trusted: node.trusted ?? false,
             useSSL: node.useSSL,
             socksProxyAddress:
-                proxy == null ? null : "${proxy.host.address}:${proxy.port}",
+              node.forceNoTor ? null : proxy == null ? null : "${proxy.host.address}:${proxy.port}",
           );
         });
       } else {
@@ -531,7 +531,7 @@ abstract class LibMoneroWallet<T extends CryptonoteCurrency>
           trusted: node.trusted ?? false,
           useSSL: node.useSSL,
           socksProxyAddress:
-              proxy == null ? null : "${proxy.host.address}:${proxy.port}",
+            node.forceNoTor ? null : proxy == null ? null : "${proxy.host.address}:${proxy.port}",
         );
       }
       libMoneroWallet?.startSyncing();


### PR DESCRIPTION
Closes #1124 
![Screenshot from 2025-04-30 16-17-55](https://github.com/user-attachments/assets/b07a5133-4d9e-4604-b6a8-87270c08617a)

The above "Bypass TOR" checkbox is only visible when the node host contains the string `localhost` or `127.0.0.1`.