### PR TITLE
Don't use GNOME's custom title bar

### DIFF
--- a/scripts/app_config/templates/linux/my_application.cc
+++ b/scripts/app_config/templates/linux/my_application.cc
@@ -20,32 +20,7 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "PlaceHolderName");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "PlaceHolderName");
-  }
+  gtk_window_set_title(window, "Stack Wallet");
 
   gtk_window_set_default_size(window, 1220, 500);
   gtk_widget_show(GTK_WIDGET(window));
@@ -98,7 +73,7 @@ static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "application-id", APPLICATION_ID,
+                                     "stack_wallet", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,
                                      nullptr));
 }


### PR DESCRIPTION
Old ugly:
<img width="1220" height="179" alt="image" src="https://github.com/user-attachments/assets/dab5c694-78c5-422e-83c4-ae5c913acfc3" />

(Hopefully) fixed nicer looking:
<img width="739" height="69" alt="image" src="https://github.com/user-attachments/assets/aa31ae8b-8bf1-4e24-9682-a9e5bf143e02" />

Lmk if this is the correct file.

Issue about the issue: https://github.com/flutter/flutter/issues/111453

Here is someone else doing it https://github.com/interstellar-app/interstellar/commit/51956c3d702c574b4b06fb332158525d6185eae7