### PR TITLE
Fix softlock caused by backing out of the "Recovery Phrase" view while restoring a Xelis wallet on Linux

### DIFF
--- a/lib/wallets/wallet/intermediate/lib_xelis_wallet.dart
+++ b/lib/wallets/wallet/intermediate/lib_xelis_wallet.dart
@@ -169,7 +169,7 @@ abstract class LibXelisWallet<T extends ElectrumCurrency>
         await _eventSubscription?.cancel();
         _eventSubscription = null;
 
-        if (wallet != null) {
+        if (wallet != null && await libXelis.isOnline(wallet!)) {
           await libXelis.offlineMode(wallet!);
         }
         await super.exit();


### PR DESCRIPTION
fix: check isOnline before offlineMode in Xelis exit()

Creating a Xelis wallet on Linux but backing out at the "Recovery Phrase" page throws
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception:
AnyhowException(Wallet is not in online mode)
#0      SimpleDecoder.decode
(package:flutter_rust_bridge/src/codec/base.dart:32)
#1      DcoCodec.decodeObject
(package:flutter_rust_bridge/src/codec/dco.dart:25)
<asynchronous suspension>
#2      LibXelisWallet.exit.<anonymous closure> (package:stackwallet/
ets/wallet/intermediate/lib_xelis_wallet.dart:173)
<asynchronous suspension>
#3      Mutex.protect (package:mutex/src/mutex.dart:79)
<asynchronous suspension>
#4      LibXelisWallet.exit (package:stackwallet/wallets/wallet/
ate/lib_xelis_wallet.dart:165)
<asynchronous suspension>
#5      _NewWalletRecoveryPhraseViewState.delete
(package:stackwallet/pages/add_wallet_views/
ew/new_wallet_recovery_phrase_view.dart:85)
<asynchronous suspension>
#6      _NewWalletRecoveryPhraseViewState.build.<anonymous closure>
(package:stackwallet/pages/add_wallet_views/
ew/new_wallet_recovery_phrase_view.dart:116)
<asynchronous suspension>

didChangeAppLifecycleState: inactive
```
and softlocks you onto that page. Neither the back button nor the "Exit to My Stack" button work to let you exit the page

This fixes that