### PR TITLE
Use cygpath on Windows CI, fall back to wslpath for WSL

### DIFF
--- a/scripts/app_config/shared/asset_generators.sh
+++ b/scripts/app_config/shared/asset_generators.sh
@@ -14,7 +14,11 @@ pushd "${APP_PROJECT_ROOT_DIR}"
 YAML_FILE="${APP_PROJECT_ROOT_DIR}/scripts/app_config/platforms/${APP_BUILD_PLATFORM}/flutter_launcher_icons.yaml"
 if [[ "${APP_BUILD_PLATFORM}" = 'windows' ]]; then
   cmd.exe /c flutter pub get
-  WIN_PATH_VERSION=$(wslpath -w ${YAML_FILE})
+  if command -v cygpath >/dev/null 2>&1; then
+    WIN_PATH_VERSION=$(cygpath -w "${YAML_FILE}")
+  else
+    WIN_PATH_VERSION=$(wslpath -w "${YAML_FILE}")
+  fi
   cmd.exe /c dart run flutter_launcher_icons -f "${WIN_PATH_VERSION}"
   # not needed in windows
 #  cmd.exe /c dart run flutter_native_splash:create

--- a/scripts/app_config/shared/link_assets.sh
+++ b/scripts/app_config/shared/link_assets.sh
@@ -23,8 +23,13 @@ for dirname in "default_themes" "icon" "lottie" "in_app_logo_icons" "svg"; do
   rm -f "${ASSETS_DIR}/${dirname}"
 
   if [[ "${APP_BUILD_PLATFORM}" = 'windows' ]]; then
-    LINK_SOURCE_DIR_WIN_PATH_VERSION=$(wslpath -w "${LINK_SOURCE_DIR}")
-    LINK_NAME_WIN_PATH_VERSION=$(wslpath -w "${ASSETS_DIR}")
+    if command -v cygpath >/dev/null 2>&1; then
+      LINK_SOURCE_DIR_WIN_PATH_VERSION=$(cygpath -w "${LINK_SOURCE_DIR}")
+      LINK_NAME_WIN_PATH_VERSION=$(cygpath -w "${ASSETS_DIR}")
+    else
+      LINK_SOURCE_DIR_WIN_PATH_VERSION=$(wslpath -w "${LINK_SOURCE_DIR}")
+      LINK_NAME_WIN_PATH_VERSION=$(wslpath -w "${ASSETS_DIR}")
+    fi
     cmd.exe /c mklink /D "${LINK_NAME_WIN_PATH_VERSION}\\${dirname}" "${LINK_SOURCE_DIR_WIN_PATH_VERSION}"
   else
     ln -s "${LINK_SOURCE_DIR}" "${ASSETS_DIR}/${dirname}"


### PR DESCRIPTION
The windows github runner uses Git Bash (MSYS2/MINGW64) where wslpath doesn't exist, breaking link_assets.sh and asset_generators.sh during the windows build.                                                                                                                                                                                                                                                                                                                                                                              

Prefer cygpath when available and keep wslpath as a fallback for local dev under WSL.                                                                                                                                                                                                    