### PR TITLE
feat: drop GNOME's custom title bar, allow to be used as in #1211

### DIFF
--- a/scripts/app_config/templates/linux/my_application.cc
+++ b/scripts/app_config/templates/linux/my_application.cc
@@ -1,9 +1,6 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -26,7 +23,7 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  gtk_window_set_title(window, "Stack Wallet");
+  gtk_window_set_title(window, "PlaceHolderName");
 
   gtk_window_set_default_size(window, 1220, 500);
   gtk_widget_show(GTK_WIDGET(window));
@@ -114,7 +111,7 @@ MyApplication* my_application_new() {
   g_set_prgname(APPLICATION_ID);
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "stack_wallet", APPLICATION_ID,
+                                     "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,
                                      nullptr));
 }

--- a/scripts/app_config/templates/linux/my_application.cc
+++ b/scripts/app_config/templates/linux/my_application.cc
@@ -26,34 +26,7 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  const char* gtk_csd_env_var = getenv("GTK_CSD");
-  gboolean use_gtk_csd = !gtk_csd_env_var || strcmp(gtk_csd_env_var, "0") != 0;
-  if (use_header_bar && use_gtk_csd) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "PlaceHolderName");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "PlaceHolderName");
-  }
+  gtk_window_set_title(window, "Stack Wallet");
 
   gtk_window_set_default_size(window, 1220, 500);
   gtk_widget_show(GTK_WIDGET(window));
@@ -141,7 +114,7 @@ MyApplication* my_application_new() {
   g_set_prgname(APPLICATION_ID);
 
   return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "application-id", APPLICATION_ID,
+                                     "stack_wallet", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,
                                      nullptr));
 }

--- a/scripts/app_config/templates/linux/my_application.cc
+++ b/scripts/app_config/templates/linux/my_application.cc
@@ -23,7 +23,19 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  gtk_window_set_title(window, "PlaceHolderName");
+  // Use a traditional title bar by default for best compatibility across
+  // desktop environments (KDE, XFCE, tiling WMs, etc.).
+  // Set GTK_CSD=1 to use a GNOME-style header bar instead.
+  const char* gtk_csd_env_var = getenv("GTK_CSD");
+  if (gtk_csd_env_var && strcmp(gtk_csd_env_var, "1") == 0) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "PlaceHolderName");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "PlaceHolderName");
+  }
 
   gtk_window_set_default_size(window, 1220, 500);
   gtk_widget_show(GTK_WIDGET(window));


### PR DESCRIPTION
Includes and supercedes https://github.com/cypherstack/stack_wallet/pull/1248

Inverts the env var introduced in https://github.com/cypherstack/stack_wallet/pull/1248 from opt-out to opt-in