### PR TITLE
fix: send server.version handshake before any ElectrumX request

### DIFF
--- a/lib/electrumx_rpc/electrumx_client.dart
+++ b/lib/electrumx_rpc/electrumx_client.dart
@@ -314,6 +314,8 @@ class ElectrumXClient {
         );
       }
 
+      await newClient.request('server.version');
+
       await ClientManager.sharedInstance.addClient(
         newClient,
         cryptoCurrency: cryptoCurrency,

--- a/lib/utilities/connection_check/electrum_connection_check.dart
+++ b/lib/utilities/connection_check/electrum_connection_check.dart
@@ -57,9 +57,9 @@ Future<bool> checkElectrumServer({
           ),
         );
 
-    await client.ping().timeout(
-      Duration(seconds: (proxyInfo == null ? 5 : 30)),
-    );
+    await client
+        .request('server.version')
+        .timeout(Duration(seconds: (proxyInfo == null ? 5 : 30)));
 
     return true;
   } catch (e, s) {


### PR DESCRIPTION
The updated electrumx-firo server enforces strict protocol negotiation: server.version must be the first message after connecting, or the server disconnects with BAD_REQUEST: use server.version to identify client (see electrumx-firo/src/electrumx/server/session.py:1056-1060). Without this handshake, all ElectrumX RPC calls fail immediately after connection. This patch adds a server.version request in two places — ElectrumXClient after creating a new client (before adding it to ClientManager) and in checkElectrumServer before the health-check ping — so both regular operation and connection probes satisfy the protocol requirement.