### PR TITLE
fix: remove double-pop from BuildingTransactionDialog cancel

### DIFF
--- a/lib/pages/exchange_view/exchange_step_views/step_4_view.dart
+++ b/lib/pages/exchange_view/exchange_step_views/step_4_view.dart
@@ -270,6 +270,7 @@ class _Step4ViewState extends ConsumerState<Step4View> {
               isSpark: wallet is FiroWallet && !firoPublicSend,
               onCancel: () {
                 wasCancelled = true;
+                Navigator.of(context).pop();
               },
             );
           },

--- a/lib/pages/salvium_stake/salvium_create_stake_view.dart
+++ b/lib/pages/salvium_stake/salvium_create_stake_view.dart
@@ -73,9 +73,8 @@ class _SalviumCreateStakeViewState
     if (_lock) return;
     _lock = true;
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       unawaited(
         showDialog<dynamic>(
           context: context,
@@ -169,7 +168,7 @@ class _SalviumCreateStakeViewState
     } catch (e, s) {
       Logging.instance.e("Salvium stake preview: ", error: e, stackTrace: s);
 
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context, rootNavigator: Util.isDesktop).pop();
 

--- a/lib/pages/send_view/send_view.dart
+++ b/lib/pages/send_view/send_view.dart
@@ -937,9 +937,8 @@ class _SendViewState extends ConsumerState<SendView> {
       }
     }
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<void>(
@@ -1162,7 +1161,7 @@ class _SendViewState extends ConsumerState<SendView> {
       }
     } catch (e, s) {
       Logging.instance.e("$e\n$s", error: e, stackTrace: s);
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context, rootNavigator: true).pop();
 

--- a/lib/pages/send_view/sol_token_send_view.dart
+++ b/lib/pages/send_view/sol_token_send_view.dart
@@ -424,9 +424,8 @@ class _SolTokenSendViewState extends ConsumerState<SolTokenSendView> {
     final wallet = ref.read(pWallets).getWallet(walletId);
     final Amount amount = _amountToSend!;
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<void>(
@@ -503,7 +502,7 @@ class _SolTokenSendViewState extends ConsumerState<SolTokenSendView> {
       }
     } catch (e, s) {
       Logging.instance.e("$e\n$s", error: e, stackTrace: s);
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context).pop();
 

--- a/lib/pages/send_view/sub_widgets/building_transaction_dialog.dart
+++ b/lib/pages/send_view/sub_widgets/building_transaction_dialog.dart
@@ -115,7 +115,6 @@ class _RestoringDialogState extends ConsumerState<BuildingTransactionDialog> {
                               style: STextStyles.itemSubtitle12(context),
                             ),
                             onPressed: () {
-                              Navigator.of(context).pop();
                               onCancel.call();
                             },
                           ),
@@ -140,7 +139,6 @@ class _RestoringDialogState extends ConsumerState<BuildingTransactionDialog> {
                     style: STextStyles.itemSubtitle12(context),
                   ),
                   onPressed: () {
-                    Navigator.of(context).pop();
                     onCancel.call();
                   },
                 ),

--- a/lib/pages/send_view/sub_widgets/building_transaction_dialog.dart
+++ b/lib/pages/send_view/sub_widgets/building_transaction_dialog.dart
@@ -145,7 +145,6 @@ class _RestoringDialogState extends ConsumerState<BuildingTransactionDialog> {
                               style: STextStyles.itemSubtitle12(context),
                             ),
                             onPressed: () {
-                              Navigator.of(context).pop();
                               onCancel.call();
                             },
                           ),
@@ -172,7 +171,6 @@ class _RestoringDialogState extends ConsumerState<BuildingTransactionDialog> {
                     style: STextStyles.itemSubtitle12(context),
                   ),
                   onPressed: () {
-                    Navigator.of(context).pop();
                     onCancel.call();
                   },
                 ),

--- a/lib/pages/send_view/token_send_view.dart
+++ b/lib/pages/send_view/token_send_view.dart
@@ -458,9 +458,8 @@ class _TokenSendViewState extends ConsumerState<TokenSendView> {
     //   }
     // }
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<void>(
@@ -533,7 +532,7 @@ class _TokenSendViewState extends ConsumerState<TokenSendView> {
       }
     } catch (e, s) {
       Logging.instance.e("$e\n$s", error: e, stackTrace: s);
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context).pop();
 

--- a/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_send.dart
+++ b/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_send.dart
@@ -540,9 +540,8 @@ class _DesktopSendState extends ConsumerState<DesktopSend> {
       }
     }
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<dynamic>(
@@ -780,7 +779,7 @@ class _DesktopSendState extends ConsumerState<DesktopSend> {
       }
     } catch (e, s) {
       Logging.instance.e("Desktop send: ", error: e, stackTrace: s);
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context, rootNavigator: true).pop();
 

--- a/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_sol_token_send.dart
+++ b/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_sol_token_send.dart
@@ -207,9 +207,8 @@ class _DesktopSolTokenSendState extends ConsumerState<DesktopSolTokenSend> {
       }
     }
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<dynamic>(
@@ -292,7 +291,7 @@ class _DesktopSolTokenSendState extends ConsumerState<DesktopSolTokenSend> {
         );
       }
     } catch (e) {
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context, rootNavigator: true).pop();
 

--- a/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_token_send.dart
+++ b/lib/pages_desktop_specific/my_stack_view/wallet_view/sub_widgets/desktop_token_send.dart
@@ -193,9 +193,8 @@ class _DesktopTokenSendState extends ConsumerState<DesktopTokenSend> {
       }
     }
 
+    bool wasCancelled = false;
     try {
-      bool wasCancelled = false;
-
       if (mounted) {
         unawaited(
           showDialog<dynamic>(
@@ -275,7 +274,7 @@ class _DesktopTokenSendState extends ConsumerState<DesktopTokenSend> {
         );
       }
     } catch (e) {
-      if (mounted) {
+      if (mounted && !wasCancelled) {
         // pop building dialog
         Navigator.of(context, rootNavigator: true).pop();
 

--- a/test/pages/send_view/building_transaction_dialog_test.dart
+++ b/test/pages/send_view/building_transaction_dialog_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,62 +13,93 @@ import 'package:stackwallet/widgets/desktop/desktop_dialog.dart';
 
 import '../../sample_data/theme_json.dart';
 
+Widget _app(Widget home) {
+  return ProviderScope(
+    overrides: [
+      coinImageSecondaryProvider.overrideWithProvider(
+        (_) => Provider((_) => 'coin.svg'),
+      ),
+    ],
+    child: MaterialApp(
+      theme: ThemeData(
+        extensions: [
+          StackColors.fromStackColorTheme(
+            StackTheme.fromJson(json: lightThemeJsonMap),
+          ),
+        ],
+      ),
+      home: home,
+    ),
+  );
+}
+
 void main() {
   for (final isDesktop in [false, true]) {
-    testWidgets(
-      'cancel dismisses only the ${isDesktop ? 'desktop' : 'mobile'} dialog',
-      (tester) async {
-        Util.screenWidth = isDesktop ? null : 400;
-        addTearDown(() => Util.screenWidth = null);
+    final label = isDesktop ? 'desktop' : 'mobile';
 
-        var cancelCount = 0;
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              coinImageSecondaryProvider.overrideWithProvider(
-                (_) => Provider((_) => 'coin.svg'),
-              ),
-            ],
-            child: MaterialApp(
-              theme: ThemeData(
-                extensions: [
-                  StackColors.fromStackColorTheme(
-                    StackTheme.fromJson(json: lightThemeJsonMap),
-                  ),
-                ],
-              ),
-              home: _RootPage(
-                isDesktop: isDesktop,
-                onCancel: () => cancelCount++,
-              ),
-            ),
-          ),
-        );
+    testWidgets('cancel dismisses only the $label dialog', (tester) async {
+      Util.screenWidth = isDesktop ? null : 400;
+      addTearDown(() => Util.screenWidth = null);
 
-        await tester.tap(find.text('Open caller'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Build transaction'));
-        await tester.pump(const Duration(milliseconds: 300));
-        await tester.tap(find.text('Cancel'));
-        await tester.pumpAndSettle();
+      var cancelCount = 0;
+      await tester.pumpWidget(
+        _app(_RootPage(isDesktop: isDesktop, onCancel: () => cancelCount++)),
+      );
 
-        expect(cancelCount, 1);
-        expect(find.byKey(const Key('caller page')), findsOneWidget);
-        expect(find.text('Generating transaction'), findsNothing);
-        expect(
-          tester.state<NavigatorState>(find.byType(Navigator)).canPop(),
-          isTrue,
-        );
-      },
-    );
+      await tester.tap(find.text('Open caller'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Build transaction'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(cancelCount, 1);
+      expect(find.byKey(const Key('caller page')), findsOneWidget);
+      expect(find.text('Generating transaction'), findsNothing);
+      expect(
+        tester.state<NavigatorState>(find.byType(Navigator)).canPop(),
+        isTrue,
+      );
+    });
+
+    testWidgets('a build failing after cancel keeps the $label caller route', (
+      tester,
+    ) async {
+      Util.screenWidth = isDesktop ? null : 400;
+      addTearDown(() => Util.screenWidth = null);
+
+      final txData = Completer<Object>();
+      await tester.pumpWidget(
+        _app(_RootPage(isDesktop: isDesktop, txData: txData)),
+      );
+
+      await tester.tap(find.text('Open caller'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Build transaction'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Generating transaction'), findsNothing);
+      expect(find.byKey(const Key('caller page')), findsOneWidget);
+
+      txData.completeError(Exception('insufficient funds'));
+      await tester.pump(const Duration(milliseconds: 2600));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('caller page')), findsOneWidget);
+      expect(find.byKey(const Key('failed dialog')), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
   }
 }
 
 class _RootPage extends StatelessWidget {
-  const _RootPage({required this.isDesktop, required this.onCancel});
+  const _RootPage({required this.isDesktop, this.onCancel, this.txData});
 
   final bool isDesktop;
-  final VoidCallback onCancel;
+  final VoidCallback? onCancel;
+  final Completer<Object>? txData;
 
   @override
   Widget build(BuildContext context) {
@@ -74,8 +107,9 @@ class _RootPage extends StatelessWidget {
       body: TextButton(
         onPressed: () => Navigator.of(context).push(
           MaterialPageRoute<void>(
-            builder: (_) =>
-                _CallerPage(isDesktop: isDesktop, onCancel: onCancel),
+            builder: (_) => txData == null
+                ? _CallerPage(isDesktop: isDesktop, onCancel: onCancel!)
+                : _PreviewCallerPage(isDesktop: isDesktop, txData: txData!),
           ),
         ),
         child: const Text('Open caller'),
@@ -111,6 +145,98 @@ class _CallerPage extends StatelessWidget {
             return isDesktop ? DesktopDialog(child: child) : child;
           },
         ),
+        child: const Text('Build transaction'),
+      ),
+    );
+  }
+}
+
+/// Mirrors the preview flow shared by the send views, which cannot be pumped
+/// directly here because they need live wallet providers.
+class _PreviewCallerPage extends StatefulWidget {
+  const _PreviewCallerPage({required this.isDesktop, required this.txData});
+
+  final bool isDesktop;
+  final Completer<Object> txData;
+
+  @override
+  State<_PreviewCallerPage> createState() => _PreviewCallerPageState();
+}
+
+class _PreviewCallerPageState extends State<_PreviewCallerPage> {
+  bool wasCancelled = false;
+
+  Future<void> _preview() async {
+    try {
+      unawaited(
+        showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) {
+            final child = BuildingTransactionDialog(
+              coin: Bitcoin(CryptoCurrencyNetwork.main),
+              isSpark: false,
+              onCancel: () {
+                wasCancelled = true;
+
+                Navigator.of(dialogContext).pop();
+              },
+            );
+
+            return widget.isDesktop ? DesktopDialog(child: child) : child;
+          },
+        ),
+      );
+
+      final time = Future<dynamic>.delayed(const Duration(milliseconds: 2500));
+      final results = await Future.wait([widget.txData.future, time]);
+
+      if (!wasCancelled && mounted) {
+        // pop building dialog
+        Navigator.of(context, rootNavigator: true).pop();
+
+        unawaited(
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => Scaffold(
+                key: const Key('confirm page'),
+                body: Text('${results.first}'),
+              ),
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (mounted && !wasCancelled) {
+        // pop building dialog
+        Navigator.of(context, rootNavigator: true).pop();
+
+        unawaited(
+          showDialog<void>(
+            context: context,
+            barrierDismissible: true,
+            builder: (dialogContext) => AlertDialog(
+              key: const Key('failed dialog'),
+              title: const Text('Transaction failed'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('Ok'),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('caller page'),
+      body: TextButton(
+        onPressed: () => unawaited(_preview()),
         child: const Text('Build transaction'),
       ),
     );

--- a/test/pages/send_view/building_transaction_dialog_test.dart
+++ b/test/pages/send_view/building_transaction_dialog_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stackwallet/models/isar/stack_theme.dart';
+import 'package:stackwallet/pages/send_view/sub_widgets/building_transaction_dialog.dart';
+import 'package:stackwallet/themes/coin_image_provider.dart';
+import 'package:stackwallet/themes/stack_colors.dart';
+import 'package:stackwallet/utilities/util.dart';
+import 'package:stackwallet/wallets/crypto_currency/crypto_currency.dart';
+import 'package:stackwallet/widgets/desktop/desktop_dialog.dart';
+
+import '../../sample_data/theme_json.dart';
+
+void main() {
+  for (final isDesktop in [false, true]) {
+    testWidgets(
+      'cancel dismisses only the ${isDesktop ? 'desktop' : 'mobile'} dialog',
+      (tester) async {
+        Util.screenWidth = isDesktop ? null : 400;
+        addTearDown(() => Util.screenWidth = null);
+
+        var cancelCount = 0;
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              coinImageSecondaryProvider.overrideWithProvider(
+                (_) => Provider((_) => 'coin.svg'),
+              ),
+            ],
+            child: MaterialApp(
+              theme: ThemeData(
+                extensions: [
+                  StackColors.fromStackColorTheme(
+                    StackTheme.fromJson(json: lightThemeJsonMap),
+                  ),
+                ],
+              ),
+              home: _RootPage(
+                isDesktop: isDesktop,
+                onCancel: () => cancelCount++,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open caller'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Build transaction'));
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(cancelCount, 1);
+        expect(find.byKey(const Key('caller page')), findsOneWidget);
+        expect(find.text('Generating transaction'), findsNothing);
+        expect(
+          tester.state<NavigatorState>(find.byType(Navigator)).canPop(),
+          isTrue,
+        );
+      },
+    );
+  }
+}
+
+class _RootPage extends StatelessWidget {
+  const _RootPage({required this.isDesktop, required this.onCancel});
+
+  final bool isDesktop;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: TextButton(
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) =>
+                _CallerPage(isDesktop: isDesktop, onCancel: onCancel),
+          ),
+        ),
+        child: const Text('Open caller'),
+      ),
+    );
+  }
+}
+
+class _CallerPage extends StatelessWidget {
+  const _CallerPage({required this.isDesktop, required this.onCancel});
+
+  final bool isDesktop;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('caller page'),
+      body: TextButton(
+        onPressed: () => showDialog<void>(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) {
+            final child = BuildingTransactionDialog(
+              coin: Bitcoin(CryptoCurrencyNetwork.main),
+              isSpark: false,
+              onCancel: () {
+                onCancel();
+                Navigator.of(dialogContext).pop();
+              },
+            );
+
+            return isDesktop ? DesktopDialog(child: child) : child;
+          },
+        ),
+        child: const Text('Build transaction'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
The dialog's cancel button popped the navigator itself and then invoked onCancel, while callers' onCancel handlers also popped, causing a double pop. Drop the internal pop so the caller owns the dismissal, and add the missing pop to Step4View's onCancel.