### PR TITLE
feat: add event-driven auto backup triggers after wallet changes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -498,6 +498,9 @@ class _MaterialAppWithThemeState extends ConsumerState<MaterialAppWithTheme>
           case BackupFrequencyType.afterClosingAWallet:
             // ignore this case here
             break;
+          case BackupFrequencyType.afterChanges:
+            ref.read(autoSWBServiceProvider);
+            break;
         }
       }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -498,6 +498,9 @@ class _MaterialAppWithThemeState extends ConsumerState<MaterialAppWithTheme>
           case BackupFrequencyType.afterClosingAWallet:
             // ignore this case here
             break;
+          case BackupFrequencyType.afterChanges:
+            // handled by note and address book edit events
+            break;
         }
       }
 

--- a/lib/pages/settings_views/global_settings_view/stack_backup_views/edit_auto_backup_view.dart
+++ b/lib/pages/settings_views/global_settings_view/stack_backup_views/edit_auto_backup_view.dart
@@ -73,6 +73,7 @@ class _EditAutoBackupViewState extends ConsumerState<EditAutoBackupView> {
     BackupFrequencyType.everyTenMinutes,
     BackupFrequencyType.everyAppStart,
     BackupFrequencyType.afterClosingAWallet,
+    BackupFrequencyType.afterChanges,
   ];
 
   String passwordFeedback =
@@ -571,6 +572,9 @@ class _EditAutoBackupViewState extends ConsumerState<EditAutoBackupView> {
                         break;
                       case BackupFrequencyType.afterClosingAWallet:
                         message = "After closing a cryptocurrency wallet";
+                        break;
+                      case BackupFrequencyType.afterChanges:
+                        message = "After editing a note or contact";
                         break;
                     }
 

--- a/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
+++ b/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
@@ -18,9 +18,7 @@ import '../../../../../utilities/enums/backup_frequency_type.dart';
 import '../../../../../utilities/text_styles.dart';
 
 class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
-  const BackupFrequencyTypeSelectSheet({
-    super.key,
-  });
+  const BackupFrequencyTypeSelectSheet({super.key});
 
   String prettyFrequencyType(BackupFrequencyType type) {
     switch (type) {
@@ -37,16 +35,15 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return WillPopScope(
       onWillPop: () async {
-        Navigator.of(context)
-            .pop(ref.read(prefsChangeNotifierProvider).backupFrequencyType);
+        Navigator.of(
+          context,
+        ).pop(ref.read(prefsChangeNotifierProvider).backupFrequencyType);
         return false;
       },
       child: Container(
         decoration: BoxDecoration(
           color: Theme.of(context).extension<StackColors>()!.popupBG,
-          borderRadius: const BorderRadius.vertical(
-            top: Radius.circular(20),
-          ),
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         ),
         child: Padding(
           padding: const EdgeInsets.only(
@@ -62,9 +59,9 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
               Center(
                 child: Container(
                   decoration: BoxDecoration(
-                    color: Theme.of(context)
-                        .extension<StackColors>()!
-                        .textFieldDefaultBG,
+                    color: Theme.of(
+                      context,
+                    ).extension<StackColors>()!.textFieldDefaultBG,
                     borderRadius: BorderRadius.circular(
                       Constants.size.circularBorderRadius,
                     ),
@@ -73,9 +70,7 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
                   height: 4,
                 ),
               ),
-              const SizedBox(
-                height: 36,
-              ),
+              const SizedBox(height: 36),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -84,9 +79,7 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
                     style: STextStyles.pageTitleH2(context),
                     textAlign: TextAlign.left,
                   ),
-                  const SizedBox(
-                    height: 24,
-                  ),
+                  const SizedBox(height: 24),
                   for (int i = 0; i < BackupFrequencyType.values.length; i++)
                     Column(
                       children: [
@@ -131,9 +124,7 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
                                     },
                                   ),
                                 ),
-                                const SizedBox(
-                                  width: 12,
-                                ),
+                                const SizedBox(width: 12),
                                 Flexible(
                                   child: Column(
                                     children: [
@@ -151,14 +142,10 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
                             ),
                           ),
                         ),
-                        const SizedBox(
-                          height: 20,
-                        ),
+                        const SizedBox(height: 20),
                       ],
                     ),
-                  const SizedBox(
-                    height: 24,
-                  ),
+                  const SizedBox(height: 24),
                 ],
               ),
             ],

--- a/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
+++ b/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
@@ -28,6 +28,8 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
         return "Every app start";
       case BackupFrequencyType.afterClosingAWallet:
         return "After closing a cryptocurrency wallet";
+      case BackupFrequencyType.afterChanges:
+        return "After editing a note or contact";
     }
   }
 

--- a/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
+++ b/lib/pages/settings_views/global_settings_view/stack_backup_views/sub_views/backup_frequency_type_select_sheet.dart
@@ -30,6 +30,8 @@ class BackupFrequencyTypeSelectSheet extends ConsumerWidget {
         return "Every app start";
       case BackupFrequencyType.afterClosingAWallet:
         return "After closing a cryptocurrency wallet";
+      case BackupFrequencyType.afterChanges:
+        return "After editing a note or contact";
     }
   }
 

--- a/lib/pages/wallet_view/transaction_views/edit_note_view.dart
+++ b/lib/pages/wallet_view/transaction_views/edit_note_view.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../models/isar/models/transaction_note.dart';
+import '../../../providers/global/auto_swb_service_provider.dart';
 import '../../../providers/providers.dart';
 import '../../../themes/stack_colors.dart';
 import '../../../utilities/constants.dart';
@@ -88,7 +89,7 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                         const Duration(milliseconds: 75),
                       );
                     }
-                    if (mounted) {
+                    if (context.mounted) {
                       Navigator.of(context).pop();
                     }
                   },
@@ -191,7 +192,11 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                                 ),
                           );
 
-                      if (mounted) {
+                      ref
+                          .read(autoSWBServiceProvider)
+                          .requestBackupAfterChange();
+
+                      if (context.mounted) {
                         Navigator.of(context).pop();
                       }
                     },
@@ -210,7 +215,10 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                                 value: _noteController.text,
                               ),
                         );
-                    if (mounted) {
+
+                    ref.read(autoSWBServiceProvider).requestBackupAfterChange();
+
+                    if (context.mounted) {
                       Navigator.of(context).pop();
                     }
                   },

--- a/lib/pages/wallet_view/transaction_views/edit_note_view.dart
+++ b/lib/pages/wallet_view/transaction_views/edit_note_view.dart
@@ -71,34 +71,33 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
       condition: !isDesktop,
       builder: (child) => Background(child: child),
       child: Scaffold(
-        backgroundColor:
-            isDesktop
-                ? Colors.transparent
-                : Theme.of(context).extension<StackColors>()!.background,
-        appBar:
-            isDesktop
-                ? null
-                : AppBar(
-                  backgroundColor:
-                      Theme.of(context).extension<StackColors>()!.background,
-                  leading: AppBarBackButton(
-                    onPressed: () async {
-                      if (FocusScope.of(context).hasFocus) {
-                        FocusScope.of(context).unfocus();
-                        await Future<void>.delayed(
-                          const Duration(milliseconds: 75),
-                        );
-                      }
-                      if (mounted) {
-                        Navigator.of(context).pop();
-                      }
-                    },
-                  ),
-                  title: Text(
-                    "Edit note",
-                    style: STextStyles.navBarTitle(context),
-                  ),
+        backgroundColor: isDesktop
+            ? Colors.transparent
+            : Theme.of(context).extension<StackColors>()!.background,
+        appBar: isDesktop
+            ? null
+            : AppBar(
+                backgroundColor: Theme.of(
+                  context,
+                ).extension<StackColors>()!.background,
+                leading: AppBarBackButton(
+                  onPressed: () async {
+                    if (FocusScope.of(context).hasFocus) {
+                      FocusScope.of(context).unfocus();
+                      await Future<void>.delayed(
+                        const Duration(milliseconds: 75),
+                      );
+                    }
+                    if (mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  },
                 ),
+                title: Text(
+                  "Edit note",
+                  style: STextStyles.navBarTitle(context),
+                ),
+              ),
         body: MobileEditNoteScaffold(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -115,10 +114,9 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                   ),
                 ),
               Padding(
-                padding:
-                    isDesktop
-                        ? const EdgeInsets.symmetric(horizontal: 32)
-                        : const EdgeInsets.all(0),
+                padding: isDesktop
+                    ? const EdgeInsets.symmetric(horizontal: 32)
+                    : const EdgeInsets.all(0),
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(
                     Constants.size.circularBorderRadius,
@@ -127,55 +125,50 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                     autocorrect: Util.isDesktop ? false : true,
                     enableSuggestions: Util.isDesktop ? false : true,
                     controller: _noteController,
-                    style:
-                        isDesktop
-                            ? STextStyles.desktopTextExtraSmall(
+                    style: isDesktop
+                        ? STextStyles.desktopTextExtraSmall(context).copyWith(
+                            color: Theme.of(
                               context,
-                            ).copyWith(
-                              color:
-                                  Theme.of(context)
-                                      .extension<StackColors>()!
-                                      .textFieldActiveText,
-                              height: 1.8,
-                            )
-                            : STextStyles.field(context),
+                            ).extension<StackColors>()!.textFieldActiveText,
+                            height: 1.8,
+                          )
+                        : STextStyles.field(context),
                     focusNode: noteFieldFocusNode,
-                    decoration: standardInputDecoration(
-                      "Note",
-                      noteFieldFocusNode,
-                      context,
-                      desktopMed: isDesktop,
-                    ).copyWith(
-                      contentPadding:
-                          isDesktop
+                    decoration:
+                        standardInputDecoration(
+                          "Note",
+                          noteFieldFocusNode,
+                          context,
+                          desktopMed: isDesktop,
+                        ).copyWith(
+                          contentPadding: isDesktop
                               ? const EdgeInsets.only(
-                                left: 16,
-                                top: 11,
-                                bottom: 12,
-                                right: 5,
-                              )
+                                  left: 16,
+                                  top: 11,
+                                  bottom: 12,
+                                  right: 5,
+                                )
                               : null,
-                      suffixIcon:
-                          _noteController.text.isNotEmpty
+                          suffixIcon: _noteController.text.isNotEmpty
                               ? Padding(
-                                padding: const EdgeInsets.only(right: 0),
-                                child: UnconstrainedBox(
-                                  child: Row(
-                                    children: [
-                                      TextFieldIconButton(
-                                        child: const XIcon(),
-                                        onTap: () async {
-                                          setState(() {
-                                            _noteController.text = "";
-                                          });
-                                        },
-                                      ),
-                                    ],
+                                  padding: const EdgeInsets.only(right: 0),
+                                  child: UnconstrainedBox(
+                                    child: Row(
+                                      children: [
+                                        TextFieldIconButton(
+                                          child: const XIcon(),
+                                          onTap: () async {
+                                            setState(() {
+                                              _noteController.text = "";
+                                            });
+                                          },
+                                        ),
+                                      ],
+                                    ),
                                   ),
-                                ),
-                              )
+                                )
                               : null,
-                    ),
+                        ),
                   ),
                 ),
               ),

--- a/lib/pages/wallet_view/transaction_views/edit_note_view.dart
+++ b/lib/pages/wallet_view/transaction_views/edit_note_view.dart
@@ -13,6 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../models/isar/models/transaction_note.dart';
 import '../../../providers/providers.dart';
+import '../../../services/auto_swb_service.dart';
 import '../../../themes/stack_colors.dart';
 import '../../../utilities/constants.dart';
 import '../../../utilities/text_styles.dart';
@@ -198,6 +199,10 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                                 ),
                           );
 
+                      AutoSWBService.requestBackupAfterChange(
+                        ref.read(prefsChangeNotifierProvider),
+                      );
+
                       if (mounted) {
                         Navigator.of(context).pop();
                       }
@@ -217,6 +222,11 @@ class _EditNoteViewState extends ConsumerState<EditNoteView> {
                                 value: _noteController.text,
                               ),
                         );
+
+                    AutoSWBService.requestBackupAfterChange(
+                      ref.read(prefsChangeNotifierProvider),
+                    );
+
                     if (mounted) {
                       Navigator.of(context).pop();
                     }

--- a/lib/pages_desktop_specific/settings/settings_menu/backup_and_restore/create_auto_backup.dart
+++ b/lib/pages_desktop_specific/settings/settings_menu/backup_and_restore/create_auto_backup.dart
@@ -86,6 +86,7 @@ class _CreateAutoBackup extends ConsumerState<CreateAutoBackup> {
     BackupFrequencyType.everyTenMinutes,
     BackupFrequencyType.everyAppStart,
     BackupFrequencyType.afterClosingAWallet,
+    BackupFrequencyType.afterChanges,
   ];
 
   Future<void> _enableAutoBackup() async {
@@ -615,6 +616,9 @@ class _CreateAutoBackup extends ConsumerState<CreateAutoBackup> {
                               break;
                             case BackupFrequencyType.afterClosingAWallet:
                               message = "After closing a cryptocurrency wallet";
+                              break;
+                            case BackupFrequencyType.afterChanges:
+                              message = "After editing a note or contact";
                               break;
                           }
 

--- a/lib/providers/global/address_book_service_provider.dart
+++ b/lib/providers/global/address_book_service_provider.dart
@@ -11,5 +11,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../services/address_book_service.dart';
 
-final addressBookServiceProvider =
-    ChangeNotifierProvider<AddressBookService>((ref) => AddressBookService());
+final addressBookServiceProvider = ChangeNotifierProvider<AddressBookService>(
+  (ref) => AddressBookService(),
+);

--- a/lib/providers/global/address_book_service_provider.dart
+++ b/lib/providers/global/address_book_service_provider.dart
@@ -9,8 +9,14 @@
  */
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../services/address_book_service.dart';
+import 'auto_swb_service_provider.dart';
 
 final addressBookServiceProvider = ChangeNotifierProvider<AddressBookService>(
-  (ref) => AddressBookService(),
+  (ref) => AddressBookService(
+    requestAutoBackup: ref
+        .read(autoSWBServiceProvider)
+        .requestBackupAfterChange,
+  ),
 );

--- a/lib/providers/global/auto_swb_service_provider.dart
+++ b/lib/providers/global/auto_swb_service_provider.dart
@@ -13,7 +13,6 @@ import 'secure_store_provider.dart';
 import '../../services/auto_swb_service.dart';
 
 final autoSWBServiceProvider = ChangeNotifierProvider<AutoSWBService>(
-  (ref) => AutoSWBService(
-    secureStorageInterface: ref.read(secureStoreProvider),
-  ),
+  (ref) =>
+      AutoSWBService(secureStorageInterface: ref.read(secureStoreProvider)),
 );

--- a/lib/providers/global/auto_swb_service_provider.dart
+++ b/lib/providers/global/auto_swb_service_provider.dart
@@ -9,10 +9,18 @@
  */
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'secure_store_provider.dart';
-import '../../services/auto_swb_service.dart';
 
-final autoSWBServiceProvider = ChangeNotifierProvider<AutoSWBService>(
-  (ref) =>
-      AutoSWBService(secureStorageInterface: ref.read(secureStoreProvider)),
-);
+import '../../services/auto_swb_service.dart';
+import '../../utilities/enums/backup_frequency_type.dart';
+import 'prefs_provider.dart';
+import 'secure_store_provider.dart';
+
+final autoSWBServiceProvider = ChangeNotifierProvider<AutoSWBService>((ref) {
+  final prefs = ref.read(prefsChangeNotifierProvider);
+  return AutoSWBService(
+    secureStorageInterface: ref.read(secureStoreProvider),
+    shouldBackupAfterChange: () =>
+        prefs.isAutoBackupEnabled &&
+        prefs.backupFrequencyType == BackupFrequencyType.afterChanges,
+  );
+});

--- a/lib/providers/global/auto_swb_service_provider.dart
+++ b/lib/providers/global/auto_swb_service_provider.dart
@@ -13,7 +13,11 @@ import 'secure_store_provider.dart';
 import '../../services/auto_swb_service.dart';
 
 final autoSWBServiceProvider = ChangeNotifierProvider<AutoSWBService>(
-  (ref) => AutoSWBService(
-    secureStorageInterface: ref.read(secureStoreProvider),
-  ),
+  (ref) {
+    final service = AutoSWBService(
+      secureStorageInterface: ref.read(secureStoreProvider),
+    );
+    AutoSWBService.instance = service;
+    return service;
+  },
 );

--- a/lib/services/address_book_service.dart
+++ b/lib/services/address_book_service.dart
@@ -8,12 +8,19 @@
  *
  */
 
+import 'dart:convert';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+
 import '../db/isar/main_db.dart';
 import '../models/isar/models/contact_entry.dart';
 
 class AddressBookService extends ChangeNotifier {
+  AddressBookService({this.requestAutoBackup});
+
+  final void Function()? requestAutoBackup;
+
   ContactEntry getContactById(String id) {
     final ContactEntry? contactEntry = MainDB.instance.getContactEntry(id: id);
     if (contactEntry == null) {
@@ -66,15 +73,28 @@ class AddressBookService extends ChangeNotifier {
     } else {
       await MainDB.instance.putContactEntry(contactEntry: contact);
       notifyListeners();
+      requestAutoBackup?.call();
       return true;
     }
   }
 
   /// Edit contact
   Future<bool> editContact(ContactEntry editedContact) async {
+    // The address book views rewrite the "default" self contact on every open.
+    // An identical write is not a user edit, so it must not notify listeners or
+    // trigger an auto backup.
+    final existing = MainDB.instance.getContactEntry(
+      id: editedContact.customId,
+    );
+    if (existing != null &&
+        jsonEncode(existing.toMap()) == jsonEncode(editedContact.toMap())) {
+      return true;
+    }
+
     // over write the contact with edited version
     await MainDB.instance.putContactEntry(contactEntry: editedContact);
     notifyListeners();
+    requestAutoBackup?.call();
     return true;
   }
 
@@ -82,5 +102,6 @@ class AddressBookService extends ChangeNotifier {
   Future<void> removeContact(String id) async {
     await MainDB.instance.deleteContactEntry(id: id);
     notifyListeners();
+    requestAutoBackup?.call();
   }
 }

--- a/lib/services/address_book_service.dart
+++ b/lib/services/address_book_service.dart
@@ -12,6 +12,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import '../db/isar/main_db.dart';
 import '../models/isar/models/contact_entry.dart';
+import '../utilities/prefs.dart';
+import 'auto_swb_service.dart';
 
 class AddressBookService extends ChangeNotifier {
   ContactEntry getContactById(String id) {
@@ -66,6 +68,7 @@ class AddressBookService extends ChangeNotifier {
     } else {
       await MainDB.instance.putContactEntry(contactEntry: contact);
       notifyListeners();
+      AutoSWBService.requestBackupAfterChange(Prefs.instance);
       return true;
     }
   }
@@ -75,6 +78,7 @@ class AddressBookService extends ChangeNotifier {
     // over write the contact with edited version
     await MainDB.instance.putContactEntry(contactEntry: editedContact);
     notifyListeners();
+    AutoSWBService.requestBackupAfterChange(Prefs.instance);
     return true;
   }
 
@@ -82,5 +86,6 @@ class AddressBookService extends ChangeNotifier {
   Future<void> removeContact(String id) async {
     await MainDB.instance.deleteContactEntry(id: id);
     notifyListeners();
+    AutoSWBService.requestBackupAfterChange(Prefs.instance);
   }
 }

--- a/lib/services/auto_swb_service.dart
+++ b/lib/services/auto_swb_service.dart
@@ -25,6 +25,9 @@ enum AutoSWBStatus { idle, backingUp, error }
 
 class AutoSWBService extends ChangeNotifier {
   Timer? _timer;
+  Timer? _debounceTimer;
+  bool _backupPending = false;
+  bool _isDisposed = false;
 
   AutoSWBStatus _status = AutoSWBStatus.idle;
   AutoSWBStatus get status => _status;
@@ -33,95 +36,124 @@ class AutoSWBService extends ChangeNotifier {
   bool get isActivePeriodicTimer => _isActiveTimer;
 
   final SecureStorageInterface secureStorageInterface;
+  final bool Function() shouldBackupAfterChange;
+  @visibleForTesting
+  final Future<void> Function()? backupRunner;
+  final Duration debounceDuration;
 
-  AutoSWBService({required this.secureStorageInterface});
+  AutoSWBService({
+    required this.secureStorageInterface,
+    required this.shouldBackupAfterChange,
+    this.backupRunner,
+    this.debounceDuration = const Duration(seconds: 5),
+  });
+
+  void requestBackupAfterChange() {
+    if (_isDisposed || !shouldBackupAfterChange()) return;
+
+    Logging.instance.d("AutoSWBService.requestBackupAfterChange() triggered");
+    // Re-checked when the timer fires: a backup writes wallet seed material,
+    // and the user can turn auto backup off inside the debounce window.
+    requestBackup(onlyIf: shouldBackupAfterChange);
+  }
+
+  void requestBackup({Duration? debounceDuration, bool Function()? onlyIf}) {
+    if (_isDisposed) return;
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(debounceDuration ?? this.debounceDuration, () {
+      _debounceTimer = null;
+      if (_isDisposed || (onlyIf != null && !onlyIf())) {
+        Logging.instance.d(
+          "AutoSWBService.requestBackup() debounce fired but the trigger "
+          "condition no longer holds; skipping backup",
+        );
+        return;
+      }
+      Logging.instance.d(
+        "AutoSWBService.requestBackup() debounce fired, running doBackup()",
+      );
+      unawaited(doBackup());
+    });
+  }
 
   /// Attempt a backup.
   Future<void> doBackup() async {
+    if (_isDisposed) return;
     if (_status == AutoSWBStatus.backingUp) {
-      Logging.instance.w(
-        "AutoSWBService attempted to run doBackup() while a backup is in progress!",
-      );
+      _backupPending = true;
       return;
     }
-    Logging.instance.d("AutoSWBService.doBackup() started...");
 
-    // set running backup status and notify listeners
-    _status = AutoSWBStatus.backingUp;
-    notifyListeners();
+    do {
+      _backupPending = false;
+      await _doBackupOnce();
+    } while (_backupPending && !_isDisposed);
+  }
+
+  Future<void> _doBackupOnce() async {
+    Logging.instance.d("AutoSWBService.doBackup() started...");
+    _setStatus(AutoSWBStatus.backingUp);
 
     try {
-      if (!Prefs.instance.isInitialized) {
-        await Prefs.instance.init();
-      }
-
-      final autoBackupDirectoryPath = Prefs.instance.autoBackupLocation;
-      if (autoBackupDirectoryPath == null) {
-        Logging.instance.e(
-          "AutoSWBService attempted to run doBackup() when no auto backup directory was set!",
-        );
-        // set error backup status and notify listeners
-        _status = AutoSWBStatus.error;
-        notifyListeners();
-        return;
-      }
-
-      final json = await SWB.createStackWalletJSON(
-        secureStorage: secureStorageInterface,
-      );
-      final jsonString = jsonEncode(json);
-
-      final adkString = await secureStorageInterface.read(
-        key: "auto_adk_string",
-      );
-
-      final adkVersionString = await secureStorageInterface.read(
-        key: "auto_adk_version_string",
-      );
-      final int adkVersion = int.parse(adkVersionString!);
-
-      final DateTime now = DateTime.now();
-      final String fileToSave = createAutoBackupFilename(
-        autoBackupDirectoryPath,
-        now,
-      );
-
-      final content = await SWB.encryptStackWalletWithADK(
-        adkString!,
-        jsonString,
-        adkVersion,
-      );
-
-      await FS.writeStringToFile(
-        content,
-        autoBackupDirectoryPath,
-        fileToSave.split("/").last,
-      );
-
-      Prefs.instance.lastAutoBackup = now;
-
-      // delete all but the latest 3 auto backups
-      trimBackups(autoBackupDirectoryPath, 3);
-
+      await (backupRunner?.call() ?? _writeBackup());
       Logging.instance.d("AutoSWBService.doBackup() succeeded");
     } on Exception catch (e, s) {
       final String err = getErrorMessageFromSWBException(e);
       Logging.instance.e("$err\n$s", error: e, stackTrace: s);
-      // set error backup status and notify listeners
-      _status = AutoSWBStatus.error;
-      notifyListeners();
+      _setStatus(AutoSWBStatus.error);
       return;
     } catch (e, s) {
       Logging.instance.e("$e\n$s", error: e, stackTrace: s);
-      // set error backup status and notify listeners
-      _status = AutoSWBStatus.error;
-      notifyListeners();
+      _setStatus(AutoSWBStatus.error);
       return;
     }
 
-    // set done/idle backup status and notify listeners
-    _status = AutoSWBStatus.idle;
-    notifyListeners();
+    _setStatus(AutoSWBStatus.idle);
+  }
+
+  Future<void> _writeBackup() async {
+    if (!Prefs.instance.isInitialized) {
+      await Prefs.instance.init();
+    }
+
+    final autoBackupDirectoryPath = Prefs.instance.autoBackupLocation;
+    if (autoBackupDirectoryPath == null) {
+      throw StateError("No auto backup directory is set");
+    }
+
+    final json = await SWB.createStackWalletJSON(
+      secureStorage: secureStorageInterface,
+    );
+    final jsonString = jsonEncode(json);
+
+    final adkString = await secureStorageInterface.read(key: "auto_adk_string");
+    final adkVersionString = await secureStorageInterface.read(
+      key: "auto_adk_version_string",
+    );
+    final adkVersion = int.parse(adkVersionString!);
+    final now = DateTime.now();
+    final fileToSave = createAutoBackupFilename(autoBackupDirectoryPath, now);
+    final content = await SWB.encryptStackWalletWithADK(
+      adkString!,
+      jsonString,
+      adkVersion,
+    );
+
+    await FS.writeStringToFile(
+      content,
+      autoBackupDirectoryPath,
+      fileToSave.split("/").last,
+    );
+
+    Prefs.instance.lastAutoBackup = now;
+    trimBackups(autoBackupDirectoryPath, 3);
+  }
+
+  void _setStatus(AutoSWBStatus status) {
+    _status = status;
+    if (!_isDisposed) {
+      notifyListeners();
+    }
   }
 
   /// Trim the number of auto backup files based on age
@@ -165,7 +197,7 @@ class AutoSWBService extends ChangeNotifier {
       (a, b) => b.item1.millisecondsSinceEpoch - a.item1.millisecondsSinceEpoch,
     );
 
-    // delete any older backups if there are more than the number we want to keep
+    // Delete backups beyond the retention limit.
     while (files.length > numberToKeep) {
       final fileToDelete = files.removeLast().item2;
       fileToDelete.deleteSync();
@@ -199,6 +231,10 @@ class AutoSWBService extends ChangeNotifier {
 
   @override
   void dispose() {
+    _isDisposed = true;
+    _backupPending = false;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
     stopPeriodicBackupTimer(shouldNotifyListeners: false);
     super.dispose();
   }

--- a/lib/services/auto_swb_service.dart
+++ b/lib/services/auto_swb_service.dart
@@ -16,6 +16,7 @@ import 'package:flutter/foundation.dart';
 import 'package:tuple/tuple.dart';
 
 import '../pages/settings_views/global_settings_view/stack_backup_views/helpers/restore_create_backup.dart';
+import '../utilities/enums/backup_frequency_type.dart';
 import '../utilities/flutter_secure_storage_interface.dart';
 import '../utilities/fs.dart';
 import '../utilities/logger.dart';
@@ -24,7 +25,12 @@ import '../utilities/prefs.dart';
 enum AutoSWBStatus { idle, backingUp, error }
 
 class AutoSWBService extends ChangeNotifier {
+  /// Static instance reference set by the provider layer so that non-widget
+  /// code (e.g. `Wallet`) can request a backup without Riverpod access.
+  static AutoSWBService? instance;
+
   Timer? _timer;
+  Timer? _debounceTimer;
 
   AutoSWBStatus _status = AutoSWBStatus.idle;
   AutoSWBStatus get status => _status;
@@ -35,6 +41,36 @@ class AutoSWBService extends ChangeNotifier {
   final SecureStorageInterface secureStorageInterface;
 
   AutoSWBService({required this.secureStorageInterface});
+
+  /// Convenience method to request a backup after an editable change such as
+  /// a transaction note or address book contact edit. Only triggers if
+  /// auto-backup is enabled and the frequency is set to
+  /// [BackupFrequencyType.afterChanges].
+  static void requestBackupAfterChange(Prefs prefs) {
+    if (instance == null) return;
+    if (!prefs.isAutoBackupEnabled) return;
+    if (prefs.backupFrequencyType != BackupFrequencyType.afterChanges) return;
+
+    Logging.instance.d(
+      "AutoSWBService.requestBackupAfterChange() triggered",
+    );
+    instance!.requestBackup();
+  }
+
+  /// Request a debounced backup. Multiple calls within [debounceDuration]
+  /// will be collapsed into a single backup. This prevents backup storms
+  /// during wallet sync or rapid changes.
+  void requestBackup({
+    Duration debounceDuration = const Duration(seconds: 5),
+  }) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(debounceDuration, () {
+      Logging.instance.d(
+        "AutoSWBService.requestBackup() debounce fired, running doBackup()",
+      );
+      doBackup();
+    });
+  }
 
   /// Attempt a backup.
   Future<void> doBackup() async {
@@ -199,6 +235,8 @@ class AutoSWBService extends ChangeNotifier {
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
     stopPeriodicBackupTimer(shouldNotifyListeners: false);
     super.dispose();
   }

--- a/lib/utilities/enums/backup_frequency_type.dart
+++ b/lib/utilities/enums/backup_frequency_type.dart
@@ -12,4 +12,5 @@ enum BackupFrequencyType {
   everyTenMinutes,
   everyAppStart,
   afterClosingAWallet,
+  afterChanges,
 }

--- a/lib/utilities/enums/backup_frequency_type.dart
+++ b/lib/utilities/enums/backup_frequency_type.dart
@@ -8,4 +8,9 @@
  *
  */
 
-enum BackupFrequencyType { everyTenMinutes, everyAppStart, afterClosingAWallet }
+enum BackupFrequencyType {
+  everyTenMinutes,
+  everyAppStart,
+  afterClosingAWallet,
+  afterChanges,
+}

--- a/lib/utilities/enums/backup_frequency_type.dart
+++ b/lib/utilities/enums/backup_frequency_type.dart
@@ -8,8 +8,4 @@
  *
  */
 
-enum BackupFrequencyType {
-  everyTenMinutes,
-  everyAppStart,
-  afterClosingAWallet,
-}
+enum BackupFrequencyType { everyTenMinutes, everyAppStart, afterClosingAWallet }

--- a/lib/utilities/format.dart
+++ b/lib/utilities/format.dart
@@ -142,6 +142,8 @@ abstract class Format {
         return "Every app start";
       case BackupFrequencyType.afterClosingAWallet:
         return "After closing a cryptocurrency wallet";
+      case BackupFrequencyType.afterChanges:
+        return "After editing a note or contact";
     }
   }
 }

--- a/lib/utilities/format.dart
+++ b/lib/utilities/format.dart
@@ -68,8 +68,9 @@ abstract class Format {
       return dayAndYear;
     }
 
-    final minutes =
-        date.minute < 10 ? "0${date.minute}" : date.minute.toString();
+    final minutes = date.minute < 10
+        ? "0${date.minute}"
+        : date.minute.toString();
     return "$dayAndYear, ${date.hour}:$minutes";
   }
 

--- a/lib/utilities/format.dart
+++ b/lib/utilities/format.dart
@@ -141,6 +141,8 @@ abstract class Format {
         return "Every app start";
       case BackupFrequencyType.afterClosingAWallet:
         return "After closing a cryptocurrency wallet";
+      case BackupFrequencyType.afterChanges:
+        return "After editing a note or contact";
     }
   }
 }

--- a/lib/utilities/prefs.dart
+++ b/lib/utilities/prefs.dart
@@ -688,6 +688,13 @@ class Prefs extends ChangeNotifier {
             value: "onWalletClose",
           );
           break;
+        case BackupFrequencyType.afterChanges:
+          DB.instance.put<dynamic>(
+            boxName: DB.boxNamePrefs,
+            key: "backupFrequencyType",
+            value: "afterChanges",
+          );
+          break;
       }
       _backupFrequencyType = backupFrequencyType;
       notifyListeners();
@@ -709,6 +716,8 @@ class Prefs extends ChangeNotifier {
         return BackupFrequencyType.everyAppStart;
       case "onWalletClose":
         return BackupFrequencyType.afterClosingAWallet;
+      case "afterChanges":
+        return BackupFrequencyType.afterChanges;
       default:
         throw Exception("Invalid Backup Frequency type found in prefs!");
     }

--- a/lib/utilities/prefs.dart
+++ b/lib/utilities/prefs.dart
@@ -681,6 +681,13 @@ class Prefs extends ChangeNotifier {
             value: "onWalletClose",
           );
           break;
+        case BackupFrequencyType.afterChanges:
+          DB.instance.put<dynamic>(
+            boxName: DB.boxNamePrefs,
+            key: "backupFrequencyType",
+            value: "afterChanges",
+          );
+          break;
       }
       _backupFrequencyType = backupFrequencyType;
       notifyListeners();
@@ -702,6 +709,8 @@ class Prefs extends ChangeNotifier {
         return BackupFrequencyType.everyAppStart;
       case "onWalletClose":
         return BackupFrequencyType.afterClosingAWallet;
+      case "afterChanges":
+        return BackupFrequencyType.afterChanges;
       default:
         throw Exception("Invalid Backup Frequency type found in prefs!");
     }

--- a/test/services/auto_swb_service_test.dart
+++ b/test/services/auto_swb_service_test.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stackwallet/services/auto_swb_service.dart';
+import 'package:stackwallet/utilities/flutter_secure_storage_interface.dart';
+
+void main() {
+  late AutoSWBService service;
+  late Future<void> Function() backupRunner;
+  var shouldBackup = true;
+  var isDisposed = false;
+
+  setUp(() {
+    shouldBackup = true;
+    isDisposed = false;
+    backupRunner = () async {};
+    service = AutoSWBService(
+      secureStorageInterface: FakeSecureStorage(),
+      shouldBackupAfterChange: () => shouldBackup,
+      backupRunner: () => backupRunner(),
+      debounceDuration: Duration.zero,
+    );
+  });
+
+  tearDown(() {
+    if (!isDisposed) {
+      service.dispose();
+    }
+  });
+
+  test('only schedules change backups when enabled', () async {
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+    };
+
+    shouldBackup = false;
+    service.requestBackupAfterChange();
+    await _flushTimers();
+    expect(backups, 0);
+
+    shouldBackup = true;
+    service.requestBackupAfterChange();
+    await _flushTimers();
+    expect(backups, 1);
+  });
+
+  test(
+    'does not back up if the gate closes inside the debounce window',
+    () async {
+      var backups = 0;
+      backupRunner = () async {
+        backups++;
+      };
+
+      service.requestBackupAfterChange();
+      // User turns auto backup off (or switches frequency) before the timer fires.
+      shouldBackup = false;
+      await _flushTimers();
+
+      expect(backups, 0);
+    },
+  );
+
+  test('coalesces a burst into one backup', () async {
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+    };
+
+    service.requestBackupAfterChange();
+    service.requestBackupAfterChange();
+    service.requestBackupAfterChange();
+    await _flushTimers();
+
+    expect(backups, 1);
+    expect(service.status, AutoSWBStatus.idle);
+  });
+
+  test('runs one follow-up for changes during an active backup', () async {
+    final firstBackup = Completer<void>();
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+      if (backups == 1) {
+        await firstBackup.future;
+      }
+    };
+
+    final runningBackup = service.doBackup();
+    await _flushTimers();
+    expect(service.status, AutoSWBStatus.backingUp);
+
+    service.requestBackupAfterChange();
+    service.requestBackupAfterChange();
+    await _flushTimers();
+    expect(backups, 1);
+
+    firstBackup.complete();
+    await runningBackup;
+
+    expect(backups, 2);
+    expect(service.status, AutoSWBStatus.idle);
+  });
+
+  test('recovers after a backup failure', () async {
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+      if (backups == 1) {
+        throw StateError('failed');
+      }
+    };
+
+    await service.doBackup();
+    expect(service.status, AutoSWBStatus.error);
+
+    await service.doBackup();
+    expect(backups, 2);
+    expect(service.status, AutoSWBStatus.idle);
+  });
+
+  test('cancels a debounced request on dispose', () async {
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+    };
+    service.requestBackup(debounceDuration: const Duration(milliseconds: 20));
+
+    service.dispose();
+    isDisposed = true;
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(backups, 0);
+  });
+
+  test('finishes an active backup safely after dispose', () async {
+    final backup = Completer<void>();
+    var backups = 0;
+    backupRunner = () async {
+      backups++;
+      await backup.future;
+    };
+
+    final runningBackup = service.doBackup();
+    await _flushTimers();
+    service.dispose();
+    isDisposed = true;
+    backup.complete();
+
+    await expectLater(runningBackup, completes);
+    service.requestBackupAfterChange();
+    await _flushTimers();
+
+    expect(backups, 1);
+    expect(service.status, AutoSWBStatus.idle);
+  });
+}
+
+Future<void> _flushTimers() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}


### PR DESCRIPTION
Fire a debounced auto-backup when a transaction note is saved or an address book contact is created, edited, or deleted.

closes #306