### PR TITLE
bump frostdart, parameterize download_all.sh

### DIFF
--- a/scripts/android/download_all.sh
+++ b/scripts/android/download_all.sh
@@ -2,16 +2,21 @@
 
 set -x -e
 
+APP="${1:-stack_wallet}"
+
 mkdir -p build
 . ./config.sh
 
 PLUGINS_DIR=../../crypto_plugins
 
-(cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/android && ./download.sh)
+if [[ "$APP" = "stack_wallet" ]]; then
+    (cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/android && ./download.sh)
+    (cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/android && ./download.sh)
+fi
 
-(cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/android && ./download.sh)
-
-(cd "${PLUGINS_DIR}"/frostdart/scripts/android && ./download.sh)
+if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
+    (cd "${PLUGINS_DIR}"/frostdart/scripts/android && ./download.sh)
+fi
 
 wait
 echo "Done"

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -117,16 +117,7 @@ fi
 
 if [ "$BUILD_CRYPTO_PLUGINS" -eq 0 ]; then
     if [ "$DOWNLOAD_CRYPTO_PLUGINS" -eq 1 ]; then
-        if [[ "$APP_NAMED_ID" = "stack_wallet" ]]; then
-            ./download_all.sh
-        elif [[ "$APP_NAMED_ID" = "stack_duo" ]]; then
-            ./build_all_duo.sh
-        elif [[ "$APP_NAMED_ID" = "campfire" ]]; then
-            ./build_all_campfire.sh
-        else
-            echo "Invalid app id: ${APP_NAMED_ID}"
-            exit 1
-        fi
+        ./download_all.sh "$APP_NAMED_ID"
     else
         if [[ "$APP_NAMED_ID" = "stack_wallet" ]]; then
             ./build_all.sh

--- a/scripts/ios/download_all.sh
+++ b/scripts/ios/download_all.sh
@@ -2,15 +2,20 @@
 
 set -x -e
 
+APP="${1:-stack_wallet}"
+
 mkdir -p build
 
 PLUGINS_DIR=../../crypto_plugins
 
-(cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/ios && ./download.sh)
+if [[ "$APP" = "stack_wallet" ]]; then
+    (cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/ios && ./download.sh)
+    (cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/ios && ./download.sh)
+fi
 
-(cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/ios && ./download.sh)
-
-(cd "${PLUGINS_DIR}"/frostdart/scripts/ios && ./download.sh)
+if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
+    (cd "${PLUGINS_DIR}"/frostdart/scripts/ios && ./download.sh)
+fi
 
 wait
 echo "Done"

--- a/scripts/linux/download_all.sh
+++ b/scripts/linux/download_all.sh
@@ -2,14 +2,19 @@
 
 set -x -e
 
+APP="${1:-stack_wallet}"
+
 mkdir -p build
 ./build_secure_storage_deps.sh
 
-(cd ../../crypto_plugins/flutter_libepiccash/scripts/linux && ./download.sh)
+if [[ "$APP" = "stack_wallet" ]]; then
+    (cd ../../crypto_plugins/flutter_libepiccash/scripts/linux && ./download.sh)
+    (cd ../../crypto_plugins/flutter_libmwc/scripts/linux && ./download.sh)
+fi
 
-(cd ../../crypto_plugins/flutter_libmwc/scripts/linux && ./download.sh)
-
-(cd ../../crypto_plugins/frostdart/scripts/linux && ./download.sh)
+if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
+    (cd ../../crypto_plugins/frostdart/scripts/linux && ./download.sh)
+fi
 
 ./build_secp256k1.sh
 

--- a/scripts/macos/download_all.sh
+++ b/scripts/macos/download_all.sh
@@ -2,15 +2,20 @@
 
 set -x -e
 
+APP="${1:-stack_wallet}"
+
 mkdir -p build
 
 PLUGINS_DIR=../../crypto_plugins
 
-(cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/macos && ./download.sh)
+if [[ "$APP" = "stack_wallet" ]]; then
+    (cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/macos && ./download.sh)
+    (cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/macos && ./download.sh)
+fi
 
-(cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/macos && ./download.sh)
-
-(cd "${PLUGINS_DIR}"/frostdart/scripts/macos && ./download.sh)
+if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
+    (cd "${PLUGINS_DIR}"/frostdart/scripts/macos && ./download.sh)
+fi
 
 wait
 echo "Done"

--- a/scripts/windows/download_all.sh
+++ b/scripts/windows/download_all.sh
@@ -2,15 +2,20 @@
 
 set -x -e
 
+APP="${1:-stack_wallet}"
+
 mkdir -p build
 
 PLUGINS_DIR=../../crypto_plugins
 
-(cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/windows && ./download.sh)
+if [[ "$APP" = "stack_wallet" ]]; then
+    (cd "${PLUGINS_DIR}"/flutter_libepiccash/scripts/windows && ./download.sh)
+    (cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/windows && ./download.sh)
+fi
 
-(cd "${PLUGINS_DIR}"/flutter_libmwc/scripts/windows && ./download.sh)
-
-(cd "${PLUGINS_DIR}"/frostdart/scripts/windows && ./download.sh)
+if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
+    (cd "${PLUGINS_DIR}"/frostdart/scripts/windows && ./download.sh)
+fi
 
 wait
 echo "Done"


### PR DESCRIPTION
Parameterize all platform download_all.sh scripts to accept an app name ($1, defaults to stack_wallet). 

libepiccash and libmwc are only downloaded for stack_wallet; frostdart is downloaded for stack_wallet and stack_duo; 
campfire downloads nothing. Nothing changed for secp256k1, secure_storage_deps.

Make the -d if/elif in build_app.sh now a single `./download_all.sh "$APP_NAMED_ID"` call.
