### PR TITLE
secp256k1 build changes

### DIFF
--- a/scripts/linux/build_all.sh
+++ b/scripts/linux/build_all.sh
@@ -26,7 +26,5 @@ if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
     (cd ../../crypto_plugins/frostdart/scripts/linux && ./build_all.sh )
 fi
 
-./build_secp256k1.sh
-
 wait
 echo "Done building"

--- a/scripts/linux/build_secp256k1.sh
+++ b/scripts/linux/build_secp256k1.sh
@@ -1,15 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
 mkdir -p build
 cd build
+
 if [ ! -d "secp256k1" ]; then
     git clone https://github.com/bitcoin-core/secp256k1
 fi
+
 cd secp256k1
 git checkout 68b55209f1ba3e6c0417789598f5f75649e9c14c
 git reset --hard
+
 rm -rf build
-mkdir -p build && cd build
+mkdir -p build
+cd build
 cmake .. -DSECP256K1_ENABLE_MODULE_RECOVERY=ON
 cmake --build .
+
+SECP_SO="$(find lib -maxdepth 1 -type f -name 'libsecp256k1.so*' | sort | head -n1)"
+if [ -z "$SECP_SO" ]; then
+    echo "[ERROR] libsecp256k1 shared library not found after build."
+    exit 1
+fi
+
+# Legacy location used by parts of the build pipeline.
 mkdir -p ../../../../../build
-cp lib/libsecp256k1.so.2.*.* "../../../../../build/libsecp256k1.so"
-cd ../../../
+cp "$SECP_SO" ../../../../../build/libsecp256k1.so
+
+# Location expected by Flutter/CMake install step.
+mkdir -p ../../../../../build/linux/x64/release/secp256k1/lib
+cp "$SECP_SO" ../../../../../build/linux/x64/release/secp256k1/lib/libsecp256k1.so

--- a/scripts/linux/build_secp256k1.sh
+++ b/scripts/linux/build_secp256k1.sh
@@ -27,7 +27,3 @@ fi
 # Legacy location used by parts of the build pipeline.
 mkdir -p ../../../../../build
 cp "$SECP_SO" ../../../../../build/libsecp256k1.so
-
-# Location expected by Flutter/CMake install step.
-mkdir -p ../../../../../build/linux/x64/release/secp256k1/lib
-cp "$SECP_SO" ../../../../../build/linux/x64/release/secp256k1/lib/libsecp256k1.so

--- a/scripts/linux/download_all.sh
+++ b/scripts/linux/download_all.sh
@@ -16,7 +16,5 @@ if [[ "$APP" = "stack_wallet" || "$APP" = "stack_duo" ]]; then
     (cd ../../crypto_plugins/frostdart/scripts/linux && ./download.sh)
 fi
 
-./build_secp256k1.sh
-
 wait
 echo "Done"


### PR DESCRIPTION
e336dd0 taken from @parasew 
https://github.com/cypherstack/stack_wallet/compare/staging...parasew:stack_wallet:staging and #1336 


  - 6e99dc7ef — linux: stage secp256k1 shared lib at CMake install path
  - 6eb985607 — linux: restore executable bit on secp256k1 builder
