### PR TITLE
fix: Salvium sync (post-fork native libs + connect status visibility)

### DIFF
--- a/lib/wallets/wallet/intermediate/lib_salvium_wallet.dart
+++ b/lib/wallets/wallet/intermediate/lib_salvium_wallet.dart
@@ -532,9 +532,9 @@ abstract class LibSalviumWallet<T extends CryptonoteCurrency>
       csSalvium.startListeners(wallet!);
       csSalvium.startAutoSaving(wallet!);
 
-      // _setSyncStatus(ConnectedSyncStatus());
+      _setSyncStatus(ConnectedSyncStatus());
     } catch (e, s) {
-      // _setSyncStatus(FailedSyncStatus());
+      _setSyncStatus(FailedSyncStatus());
       Logging.instance.e(
         "Exception caught in $runtimeType.updateNode(): ",
         error: e,


### PR DESCRIPTION
## Why

Salvium wallets cannot sync, against the default node or a self-hosted one. The default node (salvium.stackwallet.com:19081) is healthy and answers get_info/get_height over SSL, so this is client side, not a server.

Root cause: the bundled native wallet lib is pre-fork. cs_salvium_flutter_libs is the package that actually does the chain sync, and the committed lockfile is still pinned at 2.0.1 (pre-fork bins) even though the pubspec template already requires ^3.0.1. Builds only end up on 3.0.1 because plain pub get re-resolves at build time, the committed lock never reflected the fix and nothing makes it explicit/reproducible.

No published release carries the new bins yet: latest release v2.4.4 (2026-02-11) predates the bins bump (2026-05-26), so shipped Salvium has the same problem.

## What

- Pin cs_salvium_flutter_libs to 3.0.1 in pubspec.lock (only the cs_salvium_flutter_libs family moves, regenerated with flutter pub get). cs_salvium dart wrapper stays at 2.0.0 (latest) and platform_interface stays 1.0.0, both confirmed compatible by the resolve.
- Uncomment ConnectedSyncStatus / FailedSyncStatus in LibSalviumWallet.updateNode(). They were left commented from the initial salvium integration, so a failed connect only logged and the UI sat on a silent "Connecting..." spinner. Now it reports "unable to sync", matching lib_monero_wallet.

## Notes

The sync fix itself is the 3.0.1 bins. The status uncomment is for visibility, if it still fails on 3.0.1 the real error surfaces instead of a spinner. Confirmed the branch is +2 commits clean on top of staging.