### PR TITLE
Change fact0rn explorer address from non-working one.

### DIFF
--- a/lib/wallets/crypto_currency/coins/fact0rn.dart
+++ b/lib/wallets/crypto_currency/coins/fact0rn.dart
@@ -225,8 +225,7 @@ class Fact0rn extends Bip39HDCurrency with ElectrumXCurrencyInterface {
   Uri defaultBlockExplorer(String txid) {
     switch (network) {
       case CryptoCurrencyNetwork.main:
-        // "https://explorer.fact0rn.io/tx/$txid" doesn't show mempool transactions
-        return Uri.parse("https://factexplorer.io/tx/$txid");
+        return Uri.parse("https://explorer.fact0rn.io/tx/$txid");
       default:
         throw Exception(
           "Unsupported network for defaultBlockExplorer(): $network",


### PR DESCRIPTION
Per fact0rn devs, https://factexplorer.io/ is gone for good, and https://explorer.fact0rn.io/ displays unconfirmed mempool transactions.