### PR TITLE
Switch default Tezos node to tezos.stackwallet.com which doesn't supp…

### DIFF
--- a/lib/wallets/api/tezos/tezos_rpc_api.dart
+++ b/lib/wallets/api/tezos/tezos_rpc_api.dart
@@ -46,7 +46,7 @@ abstract final class TezosRpcAPI {
   }) async {
     try {
       final api =
-          "${nodeInfo.host}:${nodeInfo.port}/chains/main/blocks/head/header/shell";
+          "${nodeInfo.host}:${nodeInfo.port}/chains/main/blocks/head/header";
 
       final response = await _client.get(
         url: Uri.parse(api),

--- a/lib/wallets/crypto_currency/coins/tezos.dart
+++ b/lib/wallets/crypto_currency/coins/tezos.dart
@@ -107,8 +107,7 @@ class Tezos extends Bip39Currency {
     switch (network) {
       case CryptoCurrencyNetwork.main:
         return NodeModel(
-          // TODO: ?Change this to stack wallet one?
-          host: "https://mainnet.api.tez.ie",
+          host: "https://tezos.stackwallet.com",
           port: 443,
           name: DefaultNodes.defaultName,
           id: DefaultNodes.buildId(this),


### PR DESCRIPTION
…ort /header/shell, so getChainHeight calls /header instead, which also contains level.