### PR TITLE
[codex] Fix Firo Spark Name v2.1 registration

### DIFF
--- a/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
@@ -721,6 +721,7 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
     final List<InputV2> tempInputs = [];
     final List<OutputV2> tempOutputs = [];
 
+    var sparkNameFeeScriptSizeDelta = 0;
     for (int i = 0; i < (txData.recipients?.length ?? 0); i++) {
       if (txData.recipients![i].amount.raw == BigInt.zero) {
         continue;
@@ -741,11 +742,13 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
         _bitcoinDartNetwork,
       );
       if (txData.sparkNameInfo != null) {
+        final baseScript = scriptPubKey;
         scriptPubKey = sparkNameFeeScript(
           baseScript: scriptPubKey,
           name: txData.sparkNameInfo!.name,
           sparkAddress: txData.sparkNameInfo!.sparkAddress.value,
         );
+        sparkNameFeeScriptSizeDelta += scriptPubKey.length - baseScript.length;
       }
       txb.addOutput(
         scriptPubKey,
@@ -851,7 +854,7 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
       txHash: extractedTx.getHash(),
       additionalTxSize: txData.sparkNameInfo == null
           ? 0
-          : noProofNameTxData!.size,
+          : noProofNameTxData!.size + sparkNameFeeScriptSizeDelta,
     ));
 
     for (final outputScript in spend.outputScripts) {

--- a/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
@@ -64,7 +64,8 @@ String _hashTag(String tag) {
   return hash;
 }
 
-Uint8List _sparkNameFeeScript({
+@visibleForTesting
+Uint8List sparkNameFeeScript({
   required Uint8List baseScript,
   required String name,
   required String sparkAddress,
@@ -78,6 +79,12 @@ Uint8List _sparkNameFeeScript({
     OP_DROP,
   ]),
 ]);
+
+@visibleForTesting
+bool shouldSubtractSparkFeeFromAmount({
+  required bool isSparkNameRegistration,
+  required bool spendsAll,
+}) => !isSparkNameRegistration && spendsAll;
 
 void initSparkLogging(Level level) => libSpark.initSparkLogging(level);
 
@@ -586,7 +593,10 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
       throw Exception("Insufficient Spark balance");
     }
 
-    final bool isSendAll = available == txAmount;
+    final bool isSendAll = shouldSubtractSparkFeeFromAmount(
+      isSparkNameRegistration: txData.sparkNameInfo != null,
+      spendsAll: available == txAmount,
+    );
 
     // prepare coin data for ffi
     final serializedCoins = coins
@@ -711,6 +721,7 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
     final List<InputV2> tempInputs = [];
     final List<OutputV2> tempOutputs = [];
 
+    var sparkNameFeeScriptSizeDelta = 0;
     for (int i = 0; i < (txData.recipients?.length ?? 0); i++) {
       if (txData.recipients![i].amount.raw == BigInt.zero) {
         continue;
@@ -731,11 +742,13 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
         _bitcoinDartNetwork,
       );
       if (txData.sparkNameInfo != null) {
-        scriptPubKey = _sparkNameFeeScript(
+        final baseScript = scriptPubKey;
+        scriptPubKey = sparkNameFeeScript(
           baseScript: scriptPubKey,
           name: txData.sparkNameInfo!.name,
           sparkAddress: txData.sparkNameInfo!.sparkAddress.value,
         );
+        sparkNameFeeScriptSizeDelta += scriptPubKey.length - baseScript.length;
       }
       txb.addOutput(
         scriptPubKey,
@@ -841,7 +854,7 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
       txHash: extractedTx.getHash(),
       additionalTxSize: txData.sparkNameInfo == null
           ? 0
-          : noProofNameTxData!.size,
+          : noProofNameTxData!.size + sparkNameFeeScriptSizeDelta,
     ));
 
     for (final outputScript in spend.outputScripts) {

--- a/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
@@ -721,7 +721,6 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
     final List<InputV2> tempInputs = [];
     final List<OutputV2> tempOutputs = [];
 
-    var sparkNameFeeScriptSizeDelta = 0;
     for (int i = 0; i < (txData.recipients?.length ?? 0); i++) {
       if (txData.recipients![i].amount.raw == BigInt.zero) {
         continue;
@@ -742,13 +741,11 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
         _bitcoinDartNetwork,
       );
       if (txData.sparkNameInfo != null) {
-        final baseScript = scriptPubKey;
         scriptPubKey = sparkNameFeeScript(
           baseScript: scriptPubKey,
           name: txData.sparkNameInfo!.name,
           sparkAddress: txData.sparkNameInfo!.sparkAddress.value,
         );
-        sparkNameFeeScriptSizeDelta += scriptPubKey.length - baseScript.length;
       }
       txb.addOutput(
         scriptPubKey,
@@ -854,7 +851,7 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
       txHash: extractedTx.getHash(),
       additionalTxSize: txData.sparkNameInfo == null
           ? 0
-          : noProofNameTxData!.size + sparkNameFeeScriptSizeDelta,
+          : noProofNameTxData!.size,
     ));
 
     for (final outputScript in spend.outputScripts) {

--- a/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
+++ b/lib/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 import 'dart:math';
 
 import 'package:bitcoindart/bitcoindart.dart' as btc;
+import 'package:bitcoindart/src/utils/script.dart' as bscript;
 import 'package:coinlib_flutter/coinlib_flutter.dart' as coinlib;
 import 'package:decimal/decimal.dart';
 import 'package:flutter/foundation.dart';
@@ -50,6 +51,8 @@ const SPARK_OUT_LIMIT_PER_TX = 16;
 const OP_SPARKMINT = 0xd1;
 const OP_SPARKSMINT = 0xd2;
 const OP_SPARKSPEND = 0xd3;
+const OP_SPARKNAMEID = 0xe1;
+const OP_DROP = 0x75;
 
 /// top level function for use with [compute]
 String _hashTag(String tag) {
@@ -60,6 +63,21 @@ String _hashTag(String tag) {
   final hash = libSpark.hashTag(x, y);
   return hash;
 }
+
+Uint8List _sparkNameFeeScript({
+  required Uint8List baseScript,
+  required String name,
+  required String sparkAddress,
+}) => Uint8List.fromList([
+  ...baseScript,
+  ...bscript.compile([
+    OP_SPARKNAMEID,
+    Uint8List.fromList(utf8.encode(name)),
+    OP_DROP,
+    Uint8List.fromList(utf8.encode(sparkAddress)),
+    OP_DROP,
+  ]),
+]);
 
 void initSparkLogging(Level level) => libSpark.initSparkLogging(level);
 
@@ -708,10 +726,17 @@ mixin SparkInterface<T extends ElectrumXCurrencyInterface>
         ),
       );
 
-      final scriptPubKey = btc.Address.addressToOutputScript(
+      var scriptPubKey = btc.Address.addressToOutputScript(
         txData.recipients![i].address,
         _bitcoinDartNetwork,
       );
+      if (txData.sparkNameInfo != null) {
+        scriptPubKey = _sparkNameFeeScript(
+          baseScript: scriptPubKey,
+          name: txData.sparkNameInfo!.name,
+          sparkAddress: txData.sparkNameInfo!.sparkAddress.value,
+        );
+      }
       txb.addOutput(
         scriptPubKey,
         recipientsWithFeeSubtracted[i].amount.raw.toInt(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1028,9 +1028,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4bd84c88e1b2a817a2604ec53030634cc3304bc7"
-      resolved-ref: "4bd84c88e1b2a817a2604ec53030634cc3304bc7"
-      url: "https://github.com/cypherstack/flutter_libsparkmobile.git"
+      ref: "171bc186663e3c7a573a6240f28f430e8d6b7d50"
+      resolved-ref: "171bc186663e3c7a573a6240f28f430e8d6b7d50"
+      url: "https://github.com/firoorg/flutter_libsparkmobile.git"
     source: git
     version: "0.1.0"
   flutter_lints:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1028,9 +1028,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "53db5a06a7b7f3df68fe6263f1453f77513bec06"
-      resolved-ref: "53db5a06a7b7f3df68fe6263f1453f77513bec06"
-      url: "https://github.com/firoorg/flutter_libsparkmobile.git"
+      ref: "783bd00f0114b007f7ef97017cd10ad263ed452c"
+      resolved-ref: "783bd00f0114b007f7ef97017cd10ad263ed452c"
+      url: "https://github.com/cypherstack/flutter_libsparkmobile.git"
     source: git
     version: "0.1.0"
   flutter_lints:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1028,8 +1028,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "171bc186663e3c7a573a6240f28f430e8d6b7d50"
-      resolved-ref: "171bc186663e3c7a573a6240f28f430e8d6b7d50"
+      ref: "53db5a06a7b7f3df68fe6263f1453f77513bec06"
+      resolved-ref: "53db5a06a7b7f3df68fe6263f1453f77513bec06"
       url: "https://github.com/firoorg/flutter_libsparkmobile.git"
     source: git
     version: "0.1.0"

--- a/scripts/app_config/templates/pubspec.template.yaml
+++ b/scripts/app_config/templates/pubspec.template.yaml
@@ -43,8 +43,8 @@ dependencies:
 # %%ENABLE_FIRO%%
 #  flutter_libsparkmobile:
 #    git:
-#      url: https://github.com/firoorg/flutter_libsparkmobile.git
-#      ref: 53db5a06a7b7f3df68fe6263f1453f77513bec06
+#      url: https://github.com/cypherstack/flutter_libsparkmobile.git
+#      ref: 783bd00f0114b007f7ef97017cd10ad263ed452c
 # %%END_ENABLE_FIRO%%
 
 # %%ENABLE_EPIC%%

--- a/scripts/app_config/templates/pubspec.template.yaml
+++ b/scripts/app_config/templates/pubspec.template.yaml
@@ -44,7 +44,7 @@ dependencies:
 #  flutter_libsparkmobile:
 #    git:
 #      url: https://github.com/firoorg/flutter_libsparkmobile.git
-#      ref: 171bc186663e3c7a573a6240f28f430e8d6b7d50
+#      ref: 53db5a06a7b7f3df68fe6263f1453f77513bec06
 # %%END_ENABLE_FIRO%%
 
 # %%ENABLE_EPIC%%

--- a/scripts/app_config/templates/pubspec.template.yaml
+++ b/scripts/app_config/templates/pubspec.template.yaml
@@ -43,8 +43,8 @@ dependencies:
 # %%ENABLE_FIRO%%
 #  flutter_libsparkmobile:
 #    git:
-#      url: https://github.com/cypherstack/flutter_libsparkmobile.git
-#      ref: 4bd84c88e1b2a817a2604ec53030634cc3304bc7
+#      url: https://github.com/firoorg/flutter_libsparkmobile.git
+#      ref: 171bc186663e3c7a573a6240f28f430e8d6b7d50
 # %%END_ENABLE_FIRO%%
 
 # %%ENABLE_EPIC%%

--- a/test/wallets/spark_name_fee_test.dart
+++ b/test/wallets/spark_name_fee_test.dart
@@ -1,9 +1,16 @@
 import 'dart:typed_data';
 
+import 'package:flutter_libsparkmobile/flutter_libsparkmobile.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stackwallet/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart';
 
 void main() {
+  test('Spark Name validation rejects underscores before construction', () {
+    final pattern = RegExp(kNameRegexString);
+    expect(pattern.hasMatch('NAME-FOR.TESTING'), isTrue);
+    expect(pattern.hasMatch('NAME_FOR_TESTING'), isFalse);
+  });
+
   test('Spark Name fee output includes the name and address tag', () {
     final baseScript = Uint8List(25);
     final feeScript = sparkNameFeeScript(

--- a/test/wallets/spark_name_fee_test.dart
+++ b/test/wallets/spark_name_fee_test.dart
@@ -19,6 +19,7 @@ void main() {
       sparkAddress: List.filled(144, 'a').join(),
     );
 
+    expect(feeScript.length - baseScript.length, 155);
     expect(feeScript.length, 180);
     expect(feeScript[25], OP_SPARKNAMEID);
     expect(feeScript[32], OP_DROP);

--- a/test/wallets/spark_name_fee_test.dart
+++ b/test/wallets/spark_name_fee_test.dart
@@ -1,0 +1,35 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stackwallet/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart';
+
+void main() {
+  test('Spark Name fee size includes the tagged output bytes', () {
+    final baseScript = Uint8List(25);
+    final feeScript = sparkNameFeeScript(
+      baseScript: baseScript,
+      name: 'alice',
+      sparkAddress: List.filled(144, 'a').join(),
+    );
+
+    expect(feeScript.length - baseScript.length, 155);
+    expect(feeScript.length, 180);
+  });
+
+  test('Spark Name payments never have the miner fee subtracted', () {
+    expect(
+      shouldSubtractSparkFeeFromAmount(
+        isSparkNameRegistration: true,
+        spendsAll: true,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldSubtractSparkFeeFromAmount(
+        isSparkNameRegistration: false,
+        spendsAll: true,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/wallets/spark_name_fee_test.dart
+++ b/test/wallets/spark_name_fee_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:stackwallet/wallets/wallet/wallet_mixin_interfaces/spark_interface.dart';
 
 void main() {
-  test('Spark Name fee size includes the tagged output bytes', () {
+  test('Spark Name fee output includes the name and address tag', () {
     final baseScript = Uint8List(25);
     final feeScript = sparkNameFeeScript(
       baseScript: baseScript,
@@ -12,8 +12,10 @@ void main() {
       sparkAddress: List.filled(144, 'a').join(),
     );
 
-    expect(feeScript.length - baseScript.length, 155);
     expect(feeScript.length, 180);
+    expect(feeScript[25], OP_SPARKNAMEID);
+    expect(feeScript[32], OP_DROP);
+    expect(feeScript.last, OP_DROP);
   });
 
   test('Spark Name payments never have the miner fee subtracted', () {


### PR DESCRIPTION
## What changed

- Builds the v2.1 fee output as `P2PKH + OP_SPARKNAMEID <name> OP_DROP <sparkAddress> OP_DROP`.
- Adds the measured tagged-script byte difference to Spark Mobile's existing `additionalTxSize` input.
- Pins `cypherstack/flutter_libsparkmobile@783bd00f0114b007f7ef97017cd10ad263ed452c`, whose shared validator rejects underscores before transaction construction.
- Prevents exact-balance registration from subtracting the miner fee from the mandatory name payment.
- Adds focused validation, script-size, and fee-subtraction checks.

## Root causes

`NAME_FOR_TESTING` was rejected because Firo Core accepts only alphanumeric characters, `-`, and `.` in a Spark Name. The wrapper incorrectly allowed `_`, so Stack created a transaction that Core rejected as an invalid name.

The v2.1 tagged fee output also adds bytes that Spark Mobile's standard 34-byte transparent-output model does not include. A confirmed [`namefortesting` registration](https://explorer.firo.org/tx/3d9cd090e7a190e027705ff2aee83822646c529fbe84153448df65639fc411b9) demonstrates the exact calculation:

```text
base Spark model                         3,083
Spark Name metadata + existing margin     355
without tagged-script delta              3,438
actual serialized transaction            3,473
shortfall                                   35
measured tagged-script delta                164
final fee                                3,602
```

At Firo Core's default block minimum of 1,000 atomic units/kB, the 3,438-atom form is below the 3,473-byte transaction size and can remain unconfirmed. Measuring `taggedScript.length - baseScript.length` restores the estimator's existing 129-byte safety margin without hard-coding the tag layout.

The exact-balance path separately attempted to subtract the miner fee from the mandatory name payment. Registration now requires enough balance for both values.

## Related

- Spark Mobile v2 payload PR: https://github.com/firoorg/sparkmobile/pull/10
- Flutter wrapper validation PRs: https://github.com/firoorg/flutter_libsparkmobile/pull/1 and https://github.com/firoorg/flutter_libsparkmobile/pull/2
- Cypher Stack wrapper sync: https://github.com/cypherstack/flutter_libsparkmobile/pull/46

## Validation

- `git diff --check` passes locally.
- `NAME-FOR.TESTING` passes the corrected pattern; `NAME_FOR_TESTING` fails.
- The fee-script regression checks the measured 155-byte delta for `alice` and the required opcode structure.
- The send-all regression confirms registration never subtracts from the mandatory payment.
- Updated PR workflow passed, including dependency resolution, formatting, and tests: https://github.com/cypherstack/stack_wallet/actions/runs/29501131862/job/87630038975

