### PR TITLE
build: re-pin devicelocale to a reachable upstream commit

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -801,11 +801,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ba7d7d87a3772e972adb1358a5ec9a111b514fce
-      resolved-ref: ba7d7d87a3772e972adb1358a5ec9a111b514fce
+      ref: "73c4ed946816c5ec032d13a44f8f510e2ced9886"
+      resolved-ref: "73c4ed946816c5ec032d13a44f8f510e2ced9886"
       url: "https://github.com/cypherstack/flutter-devicelocale"
     source: git
-    version: "0.8.1"
+    version: "0.9.0"
   digest_auth:
     dependency: "direct main"
     description:

--- a/scripts/app_config/templates/pubspec.template.yaml
+++ b/scripts/app_config/templates/pubspec.template.yaml
@@ -173,7 +173,7 @@ dependencies:
   devicelocale:
     git:
       url: https://github.com/cypherstack/flutter-devicelocale
-      ref: ba7d7d87a3772e972adb1358a5ec9a111b514fce
+      ref: 73c4ed946816c5ec032d13a44f8f510e2ced9886
   device_info_plus: ^10.1.2
   keyboard_dismisser: ^3.0.0
   another_flushbar: ^1.10.28


### PR DESCRIPTION
ba7d7d87 no longer exists in cypherstack/flutter-devicelocale, so pub cannot resolve it from a cold cache and CI fails at "Get dependencies" before running anything. 73c4ed94 is the linux-changes head, which already merges master and keeps the Devicelocale.currentAsLocale API the app uses.