### PR TITLE
Firo: recognize Spark V2 spend transactions

### DIFF
--- a/lib/wallets/wallet/impl/firo_transaction_type.dart
+++ b/lib/wallets/wallet/impl/firo_transaction_type.dart
@@ -1,0 +1,4 @@
+bool isSparkSpendTransaction(Map<String, dynamic> transaction) {
+  final type = transaction['type'];
+  return transaction['version'] == 3 && (type == 9 || type == 11);
+}

--- a/lib/wallets/wallet/impl/firo_wallet.dart
+++ b/lib/wallets/wallet/impl/firo_wallet.dart
@@ -30,6 +30,7 @@ import '../wallet_mixin_interfaces/coin_control_interface.dart';
 import '../wallet_mixin_interfaces/electrumx_interface.dart';
 import '../wallet_mixin_interfaces/extended_keys_interface.dart';
 import '../wallet_mixin_interfaces/spark_interface.dart';
+import 'firo_transaction_type.dart';
 
 class MasternodeInfo {
   final String proTxHash;
@@ -332,7 +333,7 @@ class FiroWallet<T extends ElectrumXCurrencyInterface> extends Bip39HDWallet<T>
       bool isMint = false;
       bool isJMint = false;
       bool isSparkMint = false;
-      final bool isSparkSpend = txData["type"] == 9 && txData["version"] == 3;
+      final bool isSparkSpend = isSparkSpendTransaction(txData);
       final bool isMySpark = sparkTxids.contains(txData["txid"] as String);
       final bool isMySpentSpark = missing
           .where((e) => e.txid == txData["txid"])

--- a/test/wallets/firo_transaction_type_test.dart
+++ b/test/wallets/firo_transaction_type_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:paymint/wallets/wallet/impl/firo_transaction_type.dart';
+
+void main() {
+  test('recognizes Spark spend transaction types', () {
+    expect(isSparkSpendTransaction({'version': 3, 'type': 9}), isTrue);
+    expect(isSparkSpendTransaction({'version': 3, 'type': 11}), isTrue);
+    expect(isSparkSpendTransaction({'version': 3, 'type': 10}), isFalse);
+    expect(isSparkSpendTransaction({'version': 2, 'type': 11}), isFalse);
+  });
+}


### PR DESCRIPTION
H2 Spark spends use transaction type 11, while the wallet history parser recognized only legacy type 9. This left Spark fees uninitialized and interrupted wallet refresh when syncing type-11 transactions. Recognize both types and add focused regression coverage.